### PR TITLE
check if logger is instantiated by the user and tests

### DIFF
--- a/swvo/__init__.py
+++ b/swvo/__init__.py
@@ -3,3 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 __version__ = "1.0.0"
+
+import logging
+
+RED = "\033[91m"
+RESET = "\033[0m"
+
+if not logging.getLogger().hasHandlers():
+    print(f"{RED}Logger not instantiated.{RESET}")
+    print(f"{RED}Basic logger can be instantiated using `logging.basicConfig(level=logging.INFO)`{RESET}")

--- a/tests/io/test_logger.py
+++ b/tests/io/test_logger.py
@@ -15,7 +15,7 @@ class TestLogger:
         root_logger = logging.getLogger()
         for h in root_logger.handlers[:]:
             root_logger.removeHandler(h)
-
+        sys.modules.pop(module_name)
         importlib.import_module(module_name)
 
         captured = capsys.readouterr()

--- a/tests/io/test_logger.py
+++ b/tests/io/test_logger.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 GFZ Helmholtz Centre for Geosciences
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import logging
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("module_name", ["swvo", "swvo.io"])
+class TestLogger:
+    def test_logger_warning_printed(self, capsys, module_name):
+        root_logger = logging.getLogger()
+        for h in root_logger.handlers[:]:
+            root_logger.removeHandler(h)
+
+        importlib.import_module(module_name)
+
+        captured = capsys.readouterr()
+        assert "Logger not instantiated." in captured.out
+
+        sys.modules.pop(module_name)
+
+    def test_logger_warning_not_printed_when_handlers_present(self, capsys, module_name):
+        logging.basicConfig(level=logging.INFO)
+
+        importlib.import_module(module_name)
+
+        captured = capsys.readouterr()
+        assert "Logger not instantiated." not in captured.out
+        sys.modules.pop(module_name)


### PR DESCRIPTION
Closes #24 

This pull request introduces a mechanism to warn users if a logger has not been instantiated when importing the `swvo` package, and adds tests to verify this behavior.

Logger initialization warning:

* Added code in `swvo/__init__.py` to check for logger handlers and print a colored warning if none are present, along with instructions for basic logger instantiation.

Testing logger warning behavior:

* Added `tests/io/test_logger.py` to test that the logger warning is printed when no handlers are present, and not printed when handlers exist, for both `swvo` and `swvo.io` modules.