### PR TITLE
Add ty pre-commit hook scoped to swvo and dependabot for pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
+# SPDX-FileContributor: Sahil Jhawar
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version: 2
+updates:
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/astral-sh/ty-pre-commit
-    # ty version.
     rev: v0.0.63
     hooks:
       - id: ty

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,9 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    # ty version.
+    rev: v0.0.63
+    hooks:
+      - id: ty
+        files: ^swvo/


### PR DESCRIPTION
- Add astral-sh/ty-pre-commit, restricted to files under swvo/ (ty's own src.include/exclude config in pyproject.toml already scopes the check to swvo and excludes tests).
- Add .github/dependabot.yml with the pre-commit ecosystem so ruff and ty hook versions get automatic update PRs.
