### PR TITLE
feat: add `url` property

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,10 +35,10 @@ jobs:
         run: uv python install
 
       - name: Install project and ty
-        run: uv venv && uv pip install . ty
+        run: uv venv && uv pip install . ty -U
 
       - name: Run ty
-        run: uv run ty check
+        run: ty check
 
   tests:
     needs: [ruff]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,10 @@ jobs:
         run: uv python install
 
       - name: Install project and ty
-        run: uv venv && uv pip install . ty -U
+        run: |
+          uv venv
+          uv pip install . ty -U
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Run ty
         run: ty check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.63
+    rev: v0.0.64
     hooks:
       - id: ty
         files: ^swvo/

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ This package provides a set of tools for managing solar data in Python. It inclu
 from datetime import datetime, timezone
 from swvo.io.solar_wind import SWACE
 
-ACE_DIR = "./ace_data/" #data directory for ACE data
+ACE_DIR = "./ace_data/"  # data directory for ACE data
 
 start = datetime(2024, 11, 20, 0, 0, tzinfo=timezone.utc)
 end = datetime(2024, 11, 20, 6, 0, tzinfo=timezone.utc)
 
-#Read ACE solar wind data with downloading
+# Read ACE solar wind data with downloading
 ace_df = swace.read(start, end, download=True)
 ```
 

--- a/swvo/io/RBMDataSet/bin_and_interpolate_to_model_grid.py
+++ b/swvo/io/RBMDataSet/bin_and_interpolate_to_model_grid.py
@@ -154,7 +154,7 @@ def _bin_in_time(
     )
 
     if isinstance(data_time[0], np.ndarray):
-        data_time = np.asarray([t[0] for t in data_time])  # ty:ignore[invalid-assignment]
+        data_time = np.asarray([t[0] for t in data_time])
 
     sim_timestamps = [t.timestamp() for t in sim_time]
     data_timestamps = [t.timestamp() for t in data_time]

--- a/swvo/io/RBMDataSet/bin_and_interpolate_to_model_grid.py
+++ b/swvo/io/RBMDataSet/bin_and_interpolate_to_model_grid.py
@@ -154,7 +154,7 @@ def _bin_in_time(
     )
 
     if isinstance(data_time[0], np.ndarray):
-        data_time = np.asarray([t[0] for t in data_time])
+        data_time = np.asarray([t[0] for t in data_time], dtype=object)
 
     sim_timestamps = [t.timestamp() for t in sim_time]
     data_timestamps = [t.timestamp() for t in data_time]

--- a/swvo/io/RBMDataSet/interp_functions.py
+++ b/swvo/io/RBMDataSet/interp_functions.py
@@ -85,7 +85,7 @@ def _interp_flux_parallel(
                 flux_left,
                 flux_right,
                 target_al_single,
-                alpha_eq_model[it, al_left_idx],  # ty:ignore[invalid-argument-type]
+                alpha_eq_model[it, al_left_idx],
                 alpha_eq_model[it, al_right_idx],
             )
         )

--- a/swvo/io/RBMDataSet/interp_functions.py
+++ b/swvo/io/RBMDataSet/interp_functions.py
@@ -85,8 +85,8 @@ def _interp_flux_parallel(
                 flux_left,
                 flux_right,
                 target_al_single,
-                alpha_eq_model[it, al_left_idx],
-                alpha_eq_model[it, al_right_idx],
+                float(alpha_eq_model[it, al_left_idx]),
+                float(alpha_eq_model[it, al_right_idx]),
             )
         )
 

--- a/swvo/io/base.py
+++ b/swvo/io/base.py
@@ -42,6 +42,7 @@ class BaseIO(ABC):
 
     ENV_VAR_NAME: str = ""  # Must be set by subclasses
     LABEL: str = ""  # Must be set by subclasses
+    URL: str | list[str] = ""  # Should be set by subclasses; may be a single URL or a list of URLs
 
     def __init__(self, data_dir: Optional[Path] = None, prefer_env_var: bool = False) -> None:
         """Initialize the BaseIO class.
@@ -71,7 +72,49 @@ class BaseIO(ABC):
         self.data_dir: Path = Path(data_dir)
         self.data_dir.mkdir(parents=True, exist_ok=True)
 
+        self._resolved_urls: list[str] = []
+
         logger.info(f"{self.__class__.__name__} data directory: {self.data_dir}")
+
+    def _record_url(self, url: str) -> None:
+        """Record a fully resolved URL used for an actual request.
+
+        Subclasses call this right before each `requests.get`/`requests.post` with
+        the exact URL (including query params, dates, etc.) being fetched.
+        Subclasses should clear `self._resolved_urls` at the start of
+        `download_and_process` so URLs from a previous call don't linger.
+
+        Parameters
+        ----------
+        url : str
+            The fully resolved URL that was requested.
+        """
+        self._resolved_urls.append(url)
+
+    def _fallback_url(self) -> str | list[str]:
+        """URL(s) to report before any request has been resolved.
+
+        Defaults to the static `URL` template; subclasses whose base endpoint
+        attribute isn't named `URL` (e.g. `API_URL`) should override this.
+        """
+        return self.URL
+
+    @property
+    def url(self) -> str | list[str]:
+        """Source URL(s) the data is downloaded from.
+
+        If a download/read has already resolved concrete request URL(s) (e.g. with
+        dates or query parameters filled in), those are returned. Otherwise falls
+        back to `_fallback_url()`.
+
+        Returns
+        -------
+        str | list[str]
+            A single URL, or a list of URLs if more than one request was made.
+        """
+        if not self._resolved_urls:
+            return self._fallback_url()
+        return self._resolved_urls[0] if len(self._resolved_urls) == 1 else list(self._resolved_urls)
 
     @abstractmethod
     def read(self, *args, **kwargs) -> pd.DataFrame | list[pd.DataFrame]:

--- a/swvo/io/dst/wdc.py
+++ b/swvo/io/dst/wdc.py
@@ -74,6 +74,7 @@ class DSTWDC(BaseIO):
         temporary_dir = Path("./temp_wdc")
         temporary_dir.mkdir(exist_ok=True, parents=True)
 
+        self._resolved_urls = []
         file_paths, time_intervals = self._get_processed_file_list(start_time, end_time)
 
         for file_path, time_interval in zip(file_paths, time_intervals):
@@ -93,6 +94,7 @@ class DSTWDC(BaseIO):
 
             try:
                 logger.debug(f"Downloading file {URL} ...")
+                self._record_url(URL)
                 response = requests.get(URL, timeout=10)
                 if response.status_code == 404:
                     logger.warning(f"WDC Dst data not found at {URL}")

--- a/swvo/io/f10_7/swpc.py
+++ b/swvo/io/f10_7/swpc.py
@@ -46,6 +46,9 @@ class F107SWPC(BaseIO):
 
     LABEL = "swpc"
 
+    def _fallback_url(self) -> str:
+        return self.URL + self.NAME_F107
+
     def _is_within_download_range(self, target_date: datetime) -> bool:
         """Check if a date is within the last 30 days.
 

--- a/swvo/io/hp/gfz.py
+++ b/swvo/io/hp/gfz.py
@@ -51,6 +51,9 @@ class HpGFZ(BaseIO):
     API_URL = "https://kp.gfz.de/app/json/"
     LABEL = "gfz"
 
+    def _fallback_url(self) -> str:
+        return self.API_URL
+
     def __init__(self, index: str, data_dir: Optional[Path] = None, prefer_env_var: bool = False) -> None:
         """Initialize HpGFZ.
 
@@ -101,6 +104,7 @@ class HpGFZ(BaseIO):
         temporary_dir = Path("./temp_hp_wget")
         temporary_dir.mkdir(exist_ok=True, parents=True)
 
+        self._resolved_urls = []
         file_paths, time_intervals = self._get_processed_file_list(start_time, end_time)
 
         for file_path, time_interval in zip(file_paths, time_intervals):
@@ -154,6 +158,7 @@ class HpGFZ(BaseIO):
 
         url = f"{self.API_URL}?start={start_str}&end={end_str}&index={index_param}&status=def"
 
+        self._record_url(url)
         logger.debug(f"Downloading data from {url} ...")
 
         try:

--- a/swvo/io/kp/niemegk.py
+++ b/swvo/io/kp/niemegk.py
@@ -53,6 +53,9 @@ class KpNiemegk(BaseIO):
     DAYS_TO_SAVE_EACH_FILE = 3
     LABEL = "niemegk"
 
+    def _fallback_url(self) -> str:
+        return self.URL + self.NAME
+
     def download_and_process(self, start_time: datetime, end_time: datetime, reprocess_files: bool = False) -> None:
         """Download and process Niemegk Kp data file.
 

--- a/swvo/io/kp/sidc.py
+++ b/swvo/io/kp/sidc.py
@@ -91,6 +91,7 @@ class KpSIDC(BaseIO):
 
         logger.debug(f"Downloading file {self.URL} ...")
 
+        self._resolved_urls = []
         file_paths, time_intervals = self._get_processed_file_list(start_time, end_time)
         for num, (file_path, time_interval) in enumerate(zip(file_paths, time_intervals)):
             if file_path.exists() and not reprocess_files:
@@ -126,10 +127,12 @@ class KpSIDC(BaseIO):
         rmtree(temporary_dir, ignore_errors=True)
 
     def _download(self, temporary_dir, start_time: datetime, end_time: datetime) -> None:
-        response = requests.get(
+        url = (
             self.URL
             + f"&dts_start={start_time.strftime('%Y-%m-%dT%H:%M:%SZ')}&dts_end={(end_time + timedelta(seconds=1)).strftime('%Y-%m-%dT%H:%M:%SZ')}"
         )
+        self._record_url(url)
+        response = requests.get(url)
         response.raise_for_status()
 
         with open(temporary_dir, "w") as f:

--- a/swvo/io/kp/swpc.py
+++ b/swvo/io/kp/swpc.py
@@ -54,6 +54,9 @@ class KpSWPC(BaseIO):
 
     LABEL = "swpc"
 
+    def _fallback_url(self) -> str:
+        return self.URL + self.NAME
+
     def download_and_process(self, target_date: datetime, reprocess_files: bool = False) -> None:
         """
         Download and process SWPC Kp data file.

--- a/swvo/io/omni/omni_high_res.py
+++ b/swvo/io/omni/omni_high_res.py
@@ -143,6 +143,7 @@ class OMNIHighRes(BaseIO):
 
         file_paths, time_intervals = self._get_processed_file_list(start_time, end_time, cadence_min)
 
+        self._resolved_urls = []
         download_tasks = []
         for file_path, time_interval in zip(file_paths, time_intervals):
             if not reprocess_files and self._cache_contains(file_path, complete_schema):
@@ -581,6 +582,7 @@ class OMNIHighRes(BaseIO):
         else:
             payload.update({"res": "5min", "spacecraft": "omni_5min"})
         logger.debug(f"Fetching data from {self.URL} with payload: {payload}")
+        self._record_url(requests.Request("GET", self.URL, params=payload).prepare().url)  # ty:ignore[invalid-argument-type]
         response = requests.post(self.URL, data=payload, timeout=30)
         response.raise_for_status()
         data = response.text.splitlines()

--- a/swvo/io/omni/omni_low_res.py
+++ b/swvo/io/omni/omni_low_res.py
@@ -113,6 +113,7 @@ class OMNILowRes(BaseIO):
         file_paths, time_intervals = self._get_processed_file_list(start_time, end_time)
         complete_schema = [variable.name for variable in LOW_RES_VARIABLES]
 
+        self._resolved_urls = []
         with TemporaryDirectory(prefix="swvo-omni-low-res-") as temporary_dir_name:
             temporary_dir = Path(temporary_dir_name)
             for file_path, time_interval in zip(file_paths, time_intervals):
@@ -141,6 +142,7 @@ class OMNILowRes(BaseIO):
                     continue
 
     def _download(self, temporary_dir: Path, filename: str):
+        self._record_url(self.URL + filename)
         response = requests.get(self.URL + filename, timeout=10)
         response.raise_for_status()
 

--- a/swvo/io/sme/supermag.py
+++ b/swvo/io/sme/supermag.py
@@ -103,6 +103,8 @@ class SMESuperMAG(BaseIO):
                 response.raise_for_status()
 
                 data = response.text.splitlines()
+                if not data:
+                    raise ValueError("SuperMAG returned an empty response")
                 if data[0].startswith("ERROR"):
                     err = f"SuperMAG {data[0]}"
                     raise ValueError(err)

--- a/swvo/io/sme/supermag.py
+++ b/swvo/io/sme/supermag.py
@@ -53,6 +53,7 @@ class SMESuperMAG(BaseIO):
     """
 
     ENV_VAR_NAME = "SUPERMAG_STREAM_DIR"
+    URL = "https://supermag.jhuapl.edu/services/indices.php"
     LABEL = "supermag"
 
     def __init__(self, username: str, data_dir: Path | None = None, prefer_env_var: bool = False) -> None:
@@ -81,6 +82,7 @@ class SMESuperMAG(BaseIO):
         temporary_dir = Path("./temp_supermag")
         temporary_dir.mkdir(exist_ok=True, parents=True)
 
+        self._resolved_urls = []
         file_paths, time_intervals = self._get_processed_file_list(start_time, end_time)
 
         for file_path, time_interval in zip(file_paths, time_intervals):
@@ -92,15 +94,10 @@ class SMESuperMAG(BaseIO):
             try:
                 start_str = time_interval.strftime("%Y-%m-%dT%H:%M")
                 extent = int(timedelta(days=1).total_seconds())
-                url = (
-                    "https://supermag.jhuapl.edu/services/indices.php"
-                    f"?python&nohead&logon={self.username}"
-                    f"&start={start_str}"
-                    f"&extent={extent}"
-                    "&indices=sme"
-                )
+                url = f"{self.URL}?python&nohead&logon={self.username}&start={start_str}&extent={extent}&indices=sme"
 
                 logger.debug(f"Downloading data from {url} ...")
+                self._record_url(url)
 
                 response = requests.get(url, timeout=10)
                 response.raise_for_status()

--- a/swvo/io/solar_wind/ace.py
+++ b/swvo/io/solar_wind/ace.py
@@ -57,6 +57,10 @@ class SWACE(BaseIO):
 
     LABEL = "ace"
 
+    def _fallback_url(self) -> list[str]:
+        """Source URL templates, one per file (`{date}` is unresolved until a download has run)."""
+        return [self.URL + self.NAME_MAG, self.URL + self.NAME_SWEPAM]
+
     def download_and_process(self, start_time: datetime, end_time: datetime) -> None:
         """
         Download and process ACE data, splitting data across midnight into appropriate day files.
@@ -92,6 +96,7 @@ class SWACE(BaseIO):
         temporary_dir = Path("./temp_sw_ace_wget")
         temporary_dir.mkdir(exist_ok=True, parents=True)
 
+        self._resolved_urls = []
         try:
             for date in pd.date_range(start=start_time.date(), end=end_time.date(), freq="D"):
                 request_date = date.to_pydatetime().replace(tzinfo=timezone.utc)
@@ -130,6 +135,7 @@ class SWACE(BaseIO):
             If the downloaded file is empty.
         """
         logger.debug(f"Downloading file {self.URL + file_name} ...")
+        self._record_url(self.URL + file_name)
         response = requests.get(self.URL + file_name, timeout=10)
         response.raise_for_status()
 

--- a/swvo/io/solar_wind/dscovr.py
+++ b/swvo/io/solar_wind/dscovr.py
@@ -104,6 +104,7 @@ class DSCOVR(BaseIO):
         temporary_dir = Path("./temp_sw_dscovr_wget")
         temporary_dir.mkdir(exist_ok=True, parents=True)
 
+        self._resolved_urls = []
         self._download(temporary_dir, start_time, end_time)
 
         logger.debug("Processing file ...")
@@ -168,6 +169,8 @@ class DSCOVR(BaseIO):
             "time_format": "iso",
         }
         logger.debug(f"Downloading DSCOVR data from {self.URL} for {start_time} - {end_time} ...")
+        request = requests.Request("GET", self.URL, params=params).prepare()
+        self._record_url(request.url)  # ty:ignore[invalid-argument-type]
         response = requests.get(self.URL, params=params, timeout=30)
         response.raise_for_status()
 

--- a/tests/io/dst/test_dst_omni.py
+++ b/tests/io/dst/test_dst_omni.py
@@ -52,6 +52,8 @@ class TestdstOMNI:
             DSTOMNI()
 
     def test_download_and_process(self, dstomni, mocker):
+        assert dstomni.url == OMNILowRes.URL
+
         mock_response = mocker.Mock()
         mock_response.content = b"test content"
         mock_response.raise_for_status = mocker.Mock()
@@ -67,6 +69,7 @@ class TestdstOMNI:
 
         dstomni.download_and_process(start_time, end_time)
         assert (TEST_DIR / Path("data/omni2_2020.dat")).exists()
+        assert dstomni.url == OMNILowRes.URL + "omni2_2020.dat"
 
     def test_read_without_download(self, dstomni):
         start_time = datetime(2021, 1, 1, tzinfo=timezone.utc)

--- a/tests/io/dst/test_wdc.py
+++ b/tests/io/dst/test_wdc.py
@@ -97,6 +97,7 @@ DAY
         assert "WDC Dst data not found" in caplog.text
         expected_file = MOCK_DATA_PATH / "2025" / "WDC_DST_202501.csv"
         assert not expected_file.exists()
+        assert dst_instance.url == "https://wdc.kugi.kyoto-u.ac.jp/dst_realtime/202501/"
 
     def test_process_single_file(self, dst_instance, sample_dst_data):
         test_file = MOCK_DATA_PATH / "test_dst.txt"

--- a/tests/io/f10_7/test_f107omni.py
+++ b/tests/io/f10_7/test_f107omni.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 
 from swvo.io.f10_7 import F107OMNI
+from swvo.io.omni import OMNILowRes
 
 TEST_DIR = os.path.dirname(__file__)
 DATA_DIR = Path(os.path.join(TEST_DIR, "data/"))
@@ -51,6 +52,8 @@ class TestF107OMNI:
             F107OMNI()
 
     def test_download_and_process(self, f107omni, mocker):
+        assert f107omni.url == OMNILowRes.URL
+
         mock_response = mocker.Mock()
         mock_response.content = b"test content"
         mock_response.raise_for_status = mocker.Mock()
@@ -67,6 +70,7 @@ class TestF107OMNI:
         f107omni.download_and_process(start_time, end_time)
 
         assert (TEST_DIR / Path("data/omni2_2020.dat")).exists()
+        assert f107omni.url == OMNILowRes.URL + "omni2_2020.dat"
 
     def test_read_without_download(self, f107omni):
         start_time = datetime(2021, 1, 1, tzinfo=timezone.utc)

--- a/tests/io/f10_7/test_swpc.py
+++ b/tests/io/f10_7/test_swpc.py
@@ -72,6 +72,9 @@ class TestF107SWPC:
             f107 = F107SWPC()
             assert f107.data_dir == MOCK_DATA_PATH
 
+    def test_url(self, f107_instance):
+        assert f107_instance.url == "https://services.swpc.noaa.gov/text/daily-solar-indices.txt"
+
     def test_initialization_without_env_var(self):
         if F107SWPC.ENV_VAR_NAME in os.environ:
             del os.environ[F107SWPC.ENV_VAR_NAME]

--- a/tests/io/hp/test_hp.py
+++ b/tests/io/hp/test_hp.py
@@ -46,6 +46,7 @@ class TestHpGFZ:
         assert hp30gfz.index == "hp30"
         assert hp30gfz.index_number == 30
         assert isinstance(hp30gfz.data_dir, Path)
+        assert hp30gfz.url == "https://kp.gfz.de/app/json/"
 
     def test_hp60gfz_initialization(self, hp60gfz):
         assert hp60gfz.index == "hp60"
@@ -163,6 +164,7 @@ class TestHpGFZ:
             "https://kp.gfz.de/app/json/?start=2020-01-01T00:00:00Z&end=2020-12-31T00:00:00Z&index=Hp30&status=def"
         )
         mock_get.assert_called_once_with(expected_url, timeout=10)
+        assert hp30gfz.url == expected_url
 
     @pytest.fixture
     def sample_csv_data(self):

--- a/tests/io/kp/test_kp_bgs.py
+++ b/tests/io/kp/test_kp_bgs.py
@@ -37,6 +37,7 @@ class TestKpBGS:
         instance = KpBGS(data_dir=DATA_DIR)
         assert instance.data_dir == DATA_DIR
         assert instance.data_dir.exists()
+        assert instance.url == "https://geomag.bgs.ac.uk/cgi-bin/solar"
 
     def test_initialization_without_env_var(self):
         if KpBGS.ENV_VAR_NAME in os.environ:

--- a/tests/io/kp/test_kp_niemegk.py
+++ b/tests/io/kp/test_kp_niemegk.py
@@ -37,6 +37,10 @@ class TestKpNiemegk:
         assert instance.data_dir == DATA_DIR
         assert instance.data_dir.exists()
 
+    def test_url(self):
+        instance = KpNiemegk(data_dir=DATA_DIR)
+        assert instance.url == "https://kp.gfz.de/fileadmin/files_for_gfz_cms/Kp_ap_nowcast.txt"
+
     def test_initialization_without_env_var(self):
         if KpNiemegk.ENV_VAR_NAME in os.environ:
             del os.environ[KpNiemegk.ENV_VAR_NAME]

--- a/tests/io/kp/test_kp_omni.py
+++ b/tests/io/kp/test_kp_omni.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 
 from swvo.io.kp import KpOMNI
+from swvo.io.omni import OMNILowRes
 
 TEST_DIR = os.path.dirname(__file__)
 DATA_DIR = Path(os.path.join(TEST_DIR, "data/"))
@@ -50,6 +51,8 @@ class TestKpOMNI:
             KpOMNI()
 
     def test_download_and_process(self, kp_omni, mocker):
+        assert kp_omni.url == OMNILowRes.URL
+
         mock_response = mocker.Mock()
         mock_response.content = b"test content"
         mock_response.raise_for_status = mocker.Mock()
@@ -66,6 +69,7 @@ class TestKpOMNI:
         kp_omni.download_and_process(start_time, end_time)
 
         assert (TEST_DIR / Path("data/omni2_2020.dat")).exists()
+        assert kp_omni.url == OMNILowRes.URL + "omni2_2020.dat"
 
     def test_read_without_download(self, kp_omni, mocker):
         start_time = datetime(2021, 1, 1, tzinfo=timezone.utc)

--- a/tests/io/kp/test_kp_sidc.py
+++ b/tests/io/kp/test_kp_sidc.py
@@ -7,6 +7,7 @@ import os
 import shutil
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
@@ -38,6 +39,22 @@ class TestKpSIDC:
         instance = KpSIDC(data_dir=DATA_DIR)
         assert instance.data_dir == DATA_DIR
         assert instance.data_dir.exists()
+        assert instance.url == KpSIDC.URL
+
+    def test_url_reflects_resolved_request_after_download(self, kp_sidc_instance):
+        mock_response = Mock()
+        mock_response.text = "[]"
+        mock_response.raise_for_status = Mock()
+
+        start_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end_time = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+        with patch("requests.get", return_value=mock_response):
+            kp_sidc_instance.download_and_process(start_time, end_time, reprocess_files=True)
+
+        assert kp_sidc_instance.url != KpSIDC.URL
+        assert kp_sidc_instance.url.startswith(KpSIDC.URL)
+        assert "dts_start=2024-01-01T00:00:00Z" in kp_sidc_instance.url
 
     def test_initialization_without_env_var(self):
         if KpSIDC.ENV_VAR_NAME in os.environ:

--- a/tests/io/kp/test_kp_swpc.py
+++ b/tests/io/kp/test_kp_swpc.py
@@ -37,6 +37,10 @@ class TestKpSWPC:
         assert instance.data_dir == DATA_DIR
         assert instance.data_dir.exists()
 
+    def test_url(self):
+        instance = KpSWPC(data_dir=DATA_DIR)
+        assert instance.url == "https://services.swpc.noaa.gov/text/3-day-forecast.txt"
+
     def test_initialization_without_env_var(self):
         if KpSWPC.ENV_VAR_NAME in os.environ:
             del os.environ[KpSWPC.ENV_VAR_NAME]

--- a/tests/io/omni/test_omni_high_res.py
+++ b/tests/io/omni/test_omni_high_res.py
@@ -84,6 +84,26 @@ class TestOMNIHighRes:
         assert list(result.columns) == [*HIGH_RES_DEFAULT_VARIABLES, "file_name"]
         assert index[0] in result.index
 
+    def test_url_reflects_resolved_request_after_read_with_download(self, tmp_path, mocker):
+        omni_high_res = OMNIHighRes(data_dir=tmp_path)
+        assert omni_high_res.url == OMNIHighRes.URL
+
+        response = mocker.Mock()
+        response.text = "YYYY DOY HR MN\n"
+        response.raise_for_status = mocker.Mock()
+        mocker.patch("requests.post", return_value=response)
+
+        start_time = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        end_time = datetime(2020, 1, 5, tzinfo=timezone.utc)
+        with pytest.raises(ValueError):
+            # no data available for the requested interval given the stubbed empty response
+            omni_high_res.read(start_time, end_time, download=True)
+
+        assert omni_high_res.url != OMNIHighRes.URL
+        assert omni_high_res.url.startswith(OMNIHighRes.URL + "?")
+        assert "start_date=20200101" in omni_high_res.url
+        assert "end_date=20200131" in omni_high_res.url
+
     def test_download_and_process_calls_get_data_per_month(self, omni_high_res, mocker):
         start_time = datetime(2023, 1, 1, tzinfo=timezone.utc)
         end_time = datetime(2023, 12, 31, tzinfo=timezone.utc)
@@ -329,6 +349,10 @@ class TestOMNIHighRes:
         assert payload["res"] == "5min"
         assert payload["spacecraft"] == "omni_5min"
         assert post.call_args.kwargs["timeout"] == 30
+
+        assert omni_high_res.url.startswith(OMNIHighRes.URL + "?")
+        assert "res=5min" in omni_high_res.url
+        assert "spacecraft=omni_5min" in omni_high_res.url
 
     @pytest.mark.parametrize("cadence", [1, 5])
     def test_fill_values_are_masked_for_every_cadence_field(self, omni_high_res, cadence):

--- a/tests/io/omni/test_omni_low_res.py
+++ b/tests/io/omni/test_omni_low_res.py
@@ -55,6 +55,7 @@ class TestOMNILowRes:
         omni_low_res.download_and_process(start_time, end_time)
 
         assert (TEST_DIR / Path("data/omni2_2020.dat")).exists()
+        assert omni_low_res.url == OMNILowRes.URL + "omni2_2020.dat"
 
     def test_read_without_download(self, omni_low_res, mocker):
         start_time = datetime(2021, 1, 1, tzinfo=timezone.utc)

--- a/tests/io/sme/test_sme_supermag.py
+++ b/tests/io/sme/test_sme_supermag.py
@@ -80,6 +80,22 @@ class TestSMESuperMAG:
         data = pd.read_csv(expected_files[0])
         assert "sme" in data.columns
 
+    def test_url_reflects_resolved_request_after_download(self, sme_instance, mocker, mock_sme_supermag_data):
+        assert sme_instance.url == SMESuperMAG.URL
+
+        mock_response = mocker.Mock()
+        mock_response.text = mock_sme_supermag_data
+        mock_response.raise_for_status = mocker.Mock()
+        mocker.patch("requests.get", return_value=mock_response)
+
+        sme_instance.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 2))
+
+        assert sme_instance.url != SMESuperMAG.URL
+        assert isinstance(sme_instance.url, list)
+        assert all(
+            url.startswith(SMESuperMAG.URL + f"?python&nohead&logon={TEST_USERNAME}") for url in sme_instance.url
+        )
+
     def test_process_single_file(self, sme_instance, mock_sme_supermag_data):
         test_file = MOCK_DATA_PATH / "test_sme.txt"
         test_file.parent.mkdir(exist_ok=True)

--- a/tests/io/solar_wind/test_ace.py
+++ b/tests/io/solar_wind/test_ace.py
@@ -115,6 +115,7 @@ class TestSWACE:
         assert data["pdyn"].iloc[0] == pytest.approx(2e-6 * 4.2 * 380.0**2)
         assert mock_requests_get.call_args_list[0].args[0] == SWACE.URL + mag_file_name
         assert mock_requests_get.call_args_list[1].args[0] == SWACE.URL + swepam_file_name
+        assert swace_instance.url == [SWACE.URL + mag_file_name, SWACE.URL + swepam_file_name]
 
     def test_download_and_process_multiple_days(self, swace_instance):
         start_time = datetime(2024, 3, 15, 23, 0, tzinfo=timezone.utc)

--- a/tests/io/solar_wind/test_dscovr.py
+++ b/tests/io/solar_wind/test_dscovr.py
@@ -86,6 +86,8 @@ class TestDSCOVR:
         assert all(isinstance(interval, tuple) for interval in time_intervals)
 
     def test_download_and_process(self, dscovr_instance, sample_portal_payload):
+        assert dscovr_instance.url == DSCOVR.URL
+
         start_time = datetime(2024, 3, 15, 1, 0, tzinfo=timezone.utc)
         end_time = datetime(2024, 3, 15, 1, 3, tzinfo=timezone.utc)
         mock_response = Mock()
@@ -111,6 +113,9 @@ class TestDSCOVR:
         assert kwargs["params"]["format"] == "json"
         assert kwargs["params"]["time_format"] == "iso"
         assert kwargs["timeout"] == 30
+
+        assert dscovr_instance.url.startswith(DSCOVR.URL + "?")
+        assert "start_time=2024-03-15T01%3A00%3A00" in dscovr_instance.url
 
     def test_portal_parameters(self, dscovr_instance):
         parameters = dscovr_instance._portal_parameters()

--- a/tests/io/solar_wind/test_omni.py
+++ b/tests/io/solar_wind/test_omni.py
@@ -41,6 +41,23 @@ class TestSWOMNI:
     def test_download_and_process(self, swomni):
         assert swomni.download_and_process.__func__ is OMNIHighRes.download_and_process
 
+    def test_url_reflects_resolved_request(self, swomni, mocker):
+        assert swomni.url == OMNIHighRes.URL
+
+        response = mocker.Mock()
+        response.text = "YYYY DOY HR MN\n"
+        response.raise_for_status = mocker.Mock()
+        mocker.patch("requests.post", return_value=response)
+
+        swomni._get_data_from_omni(
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 2, tzinfo=timezone.utc),
+        )
+
+        assert swomni.url != OMNIHighRes.URL
+        assert swomni.url.startswith(OMNIHighRes.URL + "?")
+        assert "start_date=20200101" in swomni.url
+
     def test_read_without_download(self, swomni, mocker):
         start_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
         end_time = datetime(2021, 12, 31, tzinfo=timezone.utc)

--- a/tests/io/symh/test_symh_omni.py
+++ b/tests/io/symh/test_symh_omni.py
@@ -54,6 +54,23 @@ class TestSymhOMNI:
     def test_download_and_process(self, symhomni):
         assert symhomni.download_and_process.__func__ is OMNIHighRes.download_and_process
 
+    def test_url_reflects_resolved_request(self, symhomni, mocker):
+        assert symhomni.url == OMNIHighRes.URL
+
+        response = mocker.Mock()
+        response.text = "YYYY DOY HR MN\n"
+        response.raise_for_status = mocker.Mock()
+        mocker.patch("requests.post", return_value=response)
+
+        symhomni._get_data_from_omni(
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 2, tzinfo=timezone.utc),
+        )
+
+        assert symhomni.url != OMNIHighRes.URL
+        assert symhomni.url.startswith(OMNIHighRes.URL + "?")
+        assert "start_date=20200101" in symhomni.url
+
     def test_read_without_download(self, symhomni):
         start_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
         end_time = datetime(2021, 2, 28, tzinfo=timezone.utc)

--- a/tests/io/test_base.py
+++ b/tests/io/test_base.py
@@ -230,3 +230,60 @@ class TestBaseIOEnvironmentVariablePrecedence:
         with patch.dict(os.environ, {"TEST_DATA_DIR": str(env_dir)}):
             io = TestBaseIO(data_dir=passed_dir, prefer_env_var=True)
             assert io.data_dir == env_dir
+
+
+class TestBaseIOUrl:
+    """Test the `url` property."""
+
+    def test_url_returns_single_url(self, tmp_path):
+        """Test that url property returns the subclass's URL string as-is."""
+
+        class SingleUrl(TestBaseIO):
+            URL = "https://example.com/data/file.txt"
+
+        io = SingleUrl(data_dir=tmp_path)
+        assert io.url == "https://example.com/data/file.txt"
+
+    def test_url_returns_list_of_urls(self, tmp_path):
+        """Test that url property returns a list as-is for multi-file sources."""
+
+        class MultiUrl(TestBaseIO):
+            URL = ["https://example.com/a.txt", "https://example.com/b.txt"]
+
+        io = MultiUrl(data_dir=tmp_path)
+        assert io.url == ["https://example.com/a.txt", "https://example.com/b.txt"]
+
+    def test_url_can_override_fallback(self, tmp_path):
+        """Test that subclasses can override _fallback_url when the base attribute isn't named URL."""
+
+        class ComputedUrl(TestBaseIO):
+            API_URL = "https://example.com/file.txt"
+
+            def _fallback_url(self):
+                return self.API_URL
+
+        io = ComputedUrl(data_dir=tmp_path)
+        assert io.url == "https://example.com/file.txt"
+
+    def test_url_reflects_last_resolved_request(self, tmp_path):
+        """Test that url returns the fully resolved URL after a request was recorded."""
+
+        class RecordingUrl(TestBaseIO):
+            URL = "https://example.com/data/"
+
+        io = RecordingUrl(data_dir=tmp_path)
+        assert io.url == "https://example.com/data/"
+
+        io._record_url("https://example.com/data/2026-07-29.txt")
+        assert io.url == "https://example.com/data/2026-07-29.txt"
+
+    def test_url_returns_list_when_multiple_requests_recorded(self, tmp_path):
+        """Test that url returns a list when more than one request was made."""
+
+        class MultiRequestUrl(TestBaseIO):
+            URL = "https://example.com/data/"
+
+        io = MultiRequestUrl(data_dir=tmp_path)
+        io._record_url("https://example.com/data/a.txt")
+        io._record_url("https://example.com/data/b.txt")
+        assert io.url == ["https://example.com/data/a.txt", "https://example.com/data/b.txt"]


### PR DESCRIPTION
closes #86 
This pull request introduces a standardized mechanism for tracking and reporting the URLs used to download data in all `BaseIO` subclasses. It adds a `_resolved_urls` attribute and related methods to record the exact URLs requested (including query parameters), making it easier to audit data provenance and debug issues. Subclasses are updated to clear and record URLs appropriately, and tests are enhanced to check the new `url` property behavior.