### PR TITLE
Add SML and SMU support to the SuperMAG reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ This package provides tools to read, process, and analyze several key solar and 
     - SWPC: `F107SWPC`
     - Combined: `read_f107_from_multiple_models`
 
-- **SME Index**:  
-  The SME (SuperMAG Electrojet) index measures auroral electrojet strength based on SuperMAG ground magnetometers. Requires a valid SuperMAG account.
+- **SuperMAG electrojet indices**:
+  SME, SML, and SMU describe the auroral electrojet using the SuperMAG ground-magnetometer network at one-minute cadence. Access requires a valid SuperMAG account.
   - **Sources & Classes:**
     - SuperMAG: `SMESuperMAG`
 
@@ -96,6 +96,24 @@ This package provides tools to read, process, and analyze several key solar and 
     - Density cube container: `PlasmasphereDensityCube`
 
 Each index can be accessed via these dedicated reader classes, which handle downloading and read methods. See the code in `swvo/io` or API documentation for details on each index's implementation.
+
+## SuperMAG SME, SML, and SMU
+
+`SMESuperMAG` retains its original SME-only default and can additionally return
+SML, SMU, or all three standard electrojet indices:
+
+```python
+reader.read(start, end)  # legacy output: sme, file_name
+reader.read(start, end, variables="all")  # sme, sml, smu, file_name
+reader.read(start, end, variables=["smu", "sml"])  # caller-defined order
+```
+
+New downloads store all three indices together. Existing SME-only cache files
+continue to work for default reads and can be upgraded on demand with
+`download=True`. See the
+[SuperMAG electrojet guide](https://swvo.readthedocs.io/en/latest/supermag_indices.html)
+for authentication, cache compatibility, error handling, data references, and
+acknowledgement guidance.
 
 ## Expanded OMNI data access
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ reader.read(start, end, variables=["smu", "sml"])  # caller-defined order
 
 New downloads store all three indices together. Existing SME-only cache files
 continue to work for default reads and can be upgraded on demand with
-`download=True`. See the
+`download=True`. Historical batch downloads retry transient SuperMAG failures
+per day and continue past an unavailable day with a dated warning. See the
 [SuperMAG electrojet guide](https://swvo.readthedocs.io/en/latest/supermag_indices.html)
 for authentication, cache compatibility, error handling, data references, and
 acknowledgement guidance.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,5 +29,6 @@ User Guide
 
    Examples <examples/solar_wind_example>
    Complete OMNI variables <omni_variables>
+   SuperMAG electrojet indices <supermag_indices>
    Changelog <changelog>
    Contributing Guide <CONTRIBUTING>

--- a/docs/supermag_indices.rst
+++ b/docs/supermag_indices.rst
@@ -124,10 +124,39 @@ inclusive one-minute interval behavior. Exact historical availability and
 station participation are controlled by SuperMAG and can vary over time.
 Source fill values are returned as ``NaN``.
 
-HTTP errors, timeouts, explicit SuperMAG ``ERROR`` responses, empty or malformed
-JSON, missing response fields, and invalid timestamps are reported to the
-caller. Missing local files still produce the established warning when
-``download=False``.
+Permanent HTTP and SuperMAG ``ERROR`` responses, malformed JSON, missing
+response fields, and invalid timestamps are reported to the caller. The
+transient conditions described below are retried first. Missing local files
+still produce the established warning when ``download=False``.
+
+Transient download failures
+---------------------------
+
+SuperMAG can occasionally return an empty HTTP response for a valid historical
+day and then succeed when the same request is repeated. To make long downloads
+resilient, SWVO treats the following conditions as transient:
+
+* an empty response body or an empty JSON record array;
+* a request timeout or connection failure;
+* HTTP status ``429`` or a ``5xx`` server response.
+
+Each affected day is attempted at most four times, with bounded exponential
+backoff of one, two, and four seconds between attempts. Permanent failures,
+including an explicit SuperMAG ``ERROR`` response such as an invalid username
+and other HTTP ``4xx`` responses, are not retried.
+
+The failure policy depends on how the download is invoked:
+
+* :meth:`~swvo.io.sme.SMESuperMAG.download_and_process` continues with later
+  days after all attempts for a transiently failing day are exhausted. At the
+  end it emits a warning listing every failed date and recommends re-running
+  the same range.
+* :meth:`~swvo.io.sme.SMESuperMAG.read` with ``download=True`` remains strict.
+  If the day needed for that read still fails after all attempts, the final
+  exception is raised to the caller.
+
+No failed attempt replaces an existing cache. Temporary files are removed
+before retrying, and a later successful attempt is installed atomically.
 
 Sources and acknowledgement
 ---------------------------

--- a/docs/supermag_indices.rst
+++ b/docs/supermag_indices.rst
@@ -1,0 +1,141 @@
+.. SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
+.. SPDX-FileContributor: Simon Mischel
+..
+.. SPDX-License-Identifier: Apache-2.0
+
+SuperMAG electrojet indices
+===========================
+
+The :class:`swvo.io.sme.SMESuperMAG` reader provides the standard SuperMAG
+auroral electrojet indices at one-minute cadence. It handles authenticated
+requests, UTC conversion, fill-value masking, daily local caching, and source
+file provenance. The existing class name and import path are retained for
+backward compatibility.
+
+Available variables
+-------------------
+
+All three variables are reported in nanotesla (nT):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 18 68
+
+   * - Name
+     - SuperMAG field
+     - Description
+   * - ``sme``
+     - ``SME``
+     - SuperMAG electrojet range, defined as ``SMU - SML``. This remains the
+       default output.
+   * - ``sml``
+     - ``SML``
+     - Lower envelope of the baseline-corrected magnetic northward component
+       across the contributing auroral stations.
+   * - ``smu``
+     - ``SMU``
+     - Upper envelope of the baseline-corrected magnetic northward component
+       across the contributing auroral stations.
+
+SuperMAG fill values greater than or equal to ``999998`` are represented as
+``NaN`` for every variable.
+
+Authentication and setup
+------------------------
+
+Register for data access on the `SuperMAG website
+<https://supermag.jhuapl.edu/>`_. Supply the registered username at runtime;
+it is not stored by SWVO. The cache directory may be passed explicitly or set
+through ``SUPERMAG_STREAM_DIR``:
+
+.. code-block:: python
+
+   import os
+   from pathlib import Path
+
+   from swvo.io.sme import SMESuperMAG
+
+   reader = SMESuperMAG(
+       username=os.environ["SUPERMAG_USERNAME"],
+       data_dir=Path("./supermag_data"),
+   )
+
+The username is sent as an encoded request parameter and is intentionally
+excluded from download logs. Keep credentials in local environment variables;
+do not commit them to source control.
+
+Selecting variables
+-------------------
+
+``variables=None`` preserves the original schema and column order:
+
+.. code-block:: python
+
+   default = reader.read(start, end, download=True)
+   # columns: sme, file_name
+
+Use ``"all"`` for the complete electrojet trio:
+
+.. code-block:: python
+
+   complete = reader.read(start, end, download=True, variables="all")
+   # columns: sme, sml, smu, file_name
+
+A single name or iterable returns only those variables. Caller order is
+preserved and duplicate names are removed after their first occurrence:
+
+.. code-block:: python
+
+   sml = reader.read(start, end, variables="sml")
+   envelopes = reader.read(start, end, variables=["smu", "sml", "smu"])
+   # envelope columns: smu, sml, file_name
+
+Valid canonical names are ``sme``, ``sml``, and ``smu``. Empty selections,
+non-string entries, and unknown names raise a descriptive exception before
+files or the network are accessed.
+
+Cache layout and compatibility
+------------------------------
+
+Processed data use the established daily file name
+``SuperMAG_SME_YYYYMMDD.csv``. Newly downloaded files contain ``timestamp``,
+``sme``, ``sml``, and ``smu``. Reads add ``file_name`` provenance for rows
+that contain at least one requested value.
+
+Existing SME-only files remain valid for a default read. When SML or SMU is
+requested from such a file:
+
+* With ``download=False``, the reader leaves the cache untouched and raises an
+  error naming the absent fields and explaining how to upgrade it.
+* With ``download=True``, the reader downloads all three fields and atomically
+  replaces that daily file. A failed request, response parse, or write leaves
+  the existing cache unchanged and removes the temporary file.
+
+A corrupt cache follows the same policy: it produces remediation guidance when
+downloads are disabled and is atomically replaced when downloads are enabled.
+Complete existing caches are never downloaded again unless
+``download_and_process(..., reprocess_files=True)`` is requested.
+
+Time coverage and errors
+------------------------
+
+The returned index is timezone-aware UTC and follows the reader's established
+inclusive one-minute interval behavior. Exact historical availability and
+station participation are controlled by SuperMAG and can vary over time.
+Source fill values are returned as ``NaN``.
+
+HTTP errors, timeouts, explicit SuperMAG ``ERROR`` responses, empty or malformed
+JSON, missing response fields, and invalid timestamps are reported to the
+caller. Missing local files still produce the established warning when
+``download=False``.
+
+Sources and acknowledgement
+---------------------------
+
+Data are retrieved from the `SuperMAG indices service
+<https://supermag.jhuapl.edu/indices/>`_. Publications using these data should
+follow SuperMAG's current `acknowledgement guidance
+<https://supermag.jhuapl.edu/info/?page=acknowledgement>`_ and cite the relevant
+SuperMAG collaborators and index literature. The SME/SMU/SML construction is
+described by `Newell and Gjerloev (2011)
+<https://doi.org/10.1029/2011JA016936>`_.

--- a/swvo/io/sme/supermag.py
+++ b/swvo/io/sme/supermag.py
@@ -15,6 +15,7 @@ import warnings
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from time import sleep
 
 import numpy as np
 import pandas as pd
@@ -26,6 +27,10 @@ from swvo.io.utils import enforce_utc_timezone
 logger = logging.getLogger(__name__)
 
 logging.captureWarnings(True)
+
+
+class _TransientSuperMAGResponseError(ValueError):
+    """Response error that can reasonably succeed when requested again."""
 
 
 class SMESuperMAG(BaseIO):
@@ -60,6 +65,8 @@ class SMESuperMAG(BaseIO):
     _DEFAULT_VARIABLES = ("sme",)
     _RESPONSE_COLUMNS = {"SME": "sme", "SML": "sml", "SMU": "smu"}
     _FILL_VALUE_THRESHOLD = 999998
+    _MAX_DOWNLOAD_ATTEMPTS = 4
+    _RETRY_BACKOFF_SECONDS = 1.0
 
     def __init__(self, username: str, data_dir: Path | None = None, prefer_env_var: bool = False) -> None:
         super().__init__(data_dir, prefer_env_var)
@@ -70,7 +77,9 @@ class SMESuperMAG(BaseIO):
 
         Existing complete files are retained unless ``reprocess_files`` is
         true. A legacy SME-only file is considered incomplete and is upgraded
-        to the complete schema.
+        to the complete schema. Transient failures are retried per day. If all
+        attempts for a day fail, batch processing warns, leaves that cache
+        untouched, and continues with subsequent days.
 
         Parameters
         ----------
@@ -84,9 +93,11 @@ class SMESuperMAG(BaseIO):
         Raises
         ------
         ValueError
-            If the time range is invalid or SuperMAG returns unusable data.
+            If the time range is invalid or SuperMAG returns a permanent error,
+            such as an invalid username.
         requests.RequestException
-            If a request fails. Existing cache files remain untouched.
+            If a non-retryable request fails. Existing cache files remain
+            untouched.
         """
         if start_time >= end_time:
             raise ValueError("start_time must be before end_time")
@@ -96,10 +107,32 @@ class SMESuperMAG(BaseIO):
         self._resolved_urls = []
         file_paths, time_intervals = self._get_processed_file_list(start_time, end_time)
 
+        failed_dates = []
         for file_path, time_interval in zip(file_paths, time_intervals, strict=True):
             if file_path.exists() and not reprocess_files and self._cache_contains(file_path, self._VARIABLES):
                 continue
-            self._download_and_process_single_file(file_path, time_interval)
+            try:
+                self._download_and_process_single_file(file_path, time_interval)
+            except Exception as error:
+                if not self._is_retryable_download_error(error):
+                    raise
+                failed_dates.append(time_interval.date())
+                logger.error(
+                    "SuperMAG download failed for %s after %d attempts (%s)",
+                    time_interval.date(),
+                    self._MAX_DOWNLOAD_ATTEMPTS,
+                    self._retry_reason(error),
+                )
+
+        if failed_dates:
+            dates = ", ".join(str(date) for date in failed_dates)
+            day_label = "day" if len(failed_dates) == 1 else "days"
+            warnings.warn(
+                f"SuperMAG download failed after {self._MAX_DOWNLOAD_ATTEMPTS} attempts "
+                f"for {len(failed_dates)} {day_label}: {dates}. Re-run the same range to retry failed days.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     def _download_and_process_single_file(self, file_path: Path, time_interval: datetime) -> None:
         """Download one day and atomically replace its processed cache."""
@@ -114,20 +147,39 @@ class SMESuperMAG(BaseIO):
         }
 
         # Do not log the prepared request URL: it contains the SuperMAG username.
-        logger.debug("Downloading SuperMAG indices for %s", time_interval.date())
-        try:
-            resolved_url = requests.Request("GET", self.URL, params=params).prepare().url
-            if resolved_url is None:
-                raise ValueError("Could not resolve the SuperMAG request URL")
-            self._record_url(resolved_url)
-            response = requests.get(self.URL, params=params, timeout=10)
-            response.raise_for_status()
-            processed_df = self._process_response_text(response.text)
-            processed_df.to_csv(tmp_path, index=True, header=True)
-            tmp_path.replace(file_path)
-        except Exception:
-            tmp_path.unlink(missing_ok=True)
-            raise
+        for attempt in range(1, self._MAX_DOWNLOAD_ATTEMPTS + 1):
+            logger.debug(
+                "Downloading SuperMAG indices for %s (attempt %d/%d)",
+                time_interval.date(),
+                attempt,
+                self._MAX_DOWNLOAD_ATTEMPTS,
+            )
+            try:
+                resolved_url = requests.Request("GET", self.URL, params=params).prepare().url
+                if resolved_url is None:
+                    raise ValueError("Could not resolve the SuperMAG request URL")
+                self._record_url(resolved_url)
+                response = requests.get(self.URL, params=params, timeout=10)
+                response.raise_for_status()
+                processed_df = self._process_response_text(response.text)
+                processed_df.to_csv(tmp_path, index=True, header=True)
+                tmp_path.replace(file_path)
+                return
+            except Exception as error:
+                tmp_path.unlink(missing_ok=True)
+                if not self._is_retryable_download_error(error) or attempt == self._MAX_DOWNLOAD_ATTEMPTS:
+                    raise
+
+                backoff = self._RETRY_BACKOFF_SECONDS * 2 ** (attempt - 1)
+                logger.warning(
+                    "Transient SuperMAG failure for %s (%s); retrying in %.1f seconds (attempt %d/%d)",
+                    time_interval.date(),
+                    self._retry_reason(error),
+                    backoff,
+                    attempt + 1,
+                    self._MAX_DOWNLOAD_ATTEMPTS,
+                )
+                sleep(backoff)
 
     def _get_processed_file_list(self, start_time: datetime, end_time: datetime) -> tuple[list[Path], list[datetime]]:
         """Return daily cache paths and matching midnight request times."""
@@ -152,7 +204,7 @@ class SMESuperMAG(BaseIO):
         """Parse a SuperMAG indices response into the complete cache schema."""
         response_text = text.strip()
         if not response_text:
-            raise ValueError("SuperMAG returned an empty response")
+            raise _TransientSuperMAGResponseError("SuperMAG returned an empty response")
         if response_text.startswith("ERROR"):
             first_line = response_text.splitlines()[0]
             raise ValueError(f"SuperMAG {first_line}")
@@ -171,7 +223,9 @@ class SMESuperMAG(BaseIO):
 
         if isinstance(data, dict):
             data = [data]
-        if not isinstance(data, list) or not data:
+        if isinstance(data, list) and not data:
+            raise _TransientSuperMAGResponseError("SuperMAG returned no records")
+        if not isinstance(data, list):
             raise ValueError("SuperMAG response must contain at least one record")
 
         df = pd.DataFrame(data)
@@ -192,6 +246,29 @@ class SMESuperMAG(BaseIO):
         processed = df.loc[:, self._VARIABLES].copy()
         processed.index = pd.DatetimeIndex(timestamps, name="timestamp")
         return processed
+
+    @staticmethod
+    def _is_retryable_download_error(error: Exception) -> bool:
+        """Return whether ``error`` represents a transient download failure."""
+        if isinstance(error, (_TransientSuperMAGResponseError, requests.Timeout, requests.ConnectionError)):
+            return True
+        if isinstance(error, requests.HTTPError) and error.response is not None:
+            status_code = error.response.status_code
+            return status_code == 429 or status_code >= 500
+        return False
+
+    @staticmethod
+    def _retry_reason(error: Exception) -> str:
+        """Return a log-safe failure description without a prepared URL."""
+        if isinstance(error, _TransientSuperMAGResponseError):
+            return str(error)
+        if isinstance(error, requests.Timeout):
+            return "request timed out"
+        if isinstance(error, requests.ConnectionError):
+            return "connection failed"
+        if isinstance(error, requests.HTTPError) and error.response is not None:
+            return f"HTTP {error.response.status_code}"
+        return type(error).__name__
 
     def read(
         self,

--- a/swvo/io/sme/supermag.py
+++ b/swvo/io/sme/supermag.py
@@ -1,20 +1,20 @@
 # SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
 # SPDX-FileContributor: Dmitrii Gurev
+# SPDX-FileContributor: Simon Mischel
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Module for handling SuperMAG SME data.
-"""
+"""Read the standard SuperMAG auroral electrojet indices."""
+
+from __future__ import annotations
 
 import json
 import logging
 import re
 import warnings
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from shutil import rmtree
-from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -29,248 +29,337 @@ logging.captureWarnings(True)
 
 
 class SMESuperMAG(BaseIO):
-    """Class for SuperMAG SME data.
+    """Reader for the SuperMAG SME, SML, and SMU indices.
+
+    The legacy default remains SME only. Pass ``variables="all"`` or an
+    ordered selection to :meth:`read` to retrieve SML and SMU as well.
 
     Parameters
     ----------
     username : str
-        SuperMAG username used for authenticated data access (register at the SuperMAG website to obtain one)
+        SuperMAG username used for authenticated data access. Register at the
+        SuperMAG website to obtain one.
     data_dir : Path | None
-        Data directory for the SuperMAG SME data. If not provided, it will be read from the environment variable
+        Directory containing daily processed files. If omitted, the path is
+        read from ``SUPERMAG_STREAM_DIR``.
     prefer_env_var : bool, optional
-        If True, the environment variable takes precedence over the passed data_dir argument.
-        If False (default), the passed data_dir is used if provided, otherwise the environment variable is used.
-
-    Methods
-    -------
-    download_and_process
-    read
+        If ``True``, the environment variable takes precedence over
+        ``data_dir``. Defaults to ``False``.
 
     Raises
     ------
     ValueError
-        Raised if the required environment variable is not set.
+        If neither ``data_dir`` nor ``SUPERMAG_STREAM_DIR`` is available.
     """
 
     ENV_VAR_NAME = "SUPERMAG_STREAM_DIR"
     URL = "https://supermag.jhuapl.edu/services/indices.php"
     LABEL = "supermag"
 
+    _VARIABLES = ("sme", "sml", "smu")
+    _DEFAULT_VARIABLES = ("sme",)
+    _RESPONSE_COLUMNS = {"SME": "sme", "SML": "sml", "SMU": "smu"}
+    _FILL_VALUE_THRESHOLD = 999998
+
     def __init__(self, username: str, data_dir: Path | None = None, prefer_env_var: bool = False) -> None:
         super().__init__(data_dir, prefer_env_var)
         self.username = username
 
     def download_and_process(self, start_time: datetime, end_time: datetime, reprocess_files: bool = False) -> None:
-        """Download and process SuperMAG SME data files.
+        """Download complete daily SME/SML/SMU files.
+
+        Existing complete files are retained unless ``reprocess_files`` is
+        true. A legacy SME-only file is considered incomplete and is upgraded
+        to the complete schema.
 
         Parameters
         ----------
         start_time : datetime
-            Start time of the data to download. Must be timezone-aware.
+            First requested instant. Naive values are interpreted as UTC.
         end_time : datetime
-            End time of the data to download. Must be timezone-aware.
+            Last requested instant. Naive values are interpreted as UTC.
         reprocess_files : bool, optional
-            Download and process files again. Defaults to False.
-
-        Returns
-        -------
-        None
-        """
-
-        assert start_time < end_time, "Start time must be before end time"
-
-        temporary_dir = Path("./temp_supermag")
-        temporary_dir.mkdir(exist_ok=True, parents=True)
-
-        self._resolved_urls = []
-        file_paths, time_intervals = self._get_processed_file_list(start_time, end_time)
-
-        for file_path, time_interval in zip(file_paths, time_intervals):
-            if file_path.exists() and not reprocess_files:
-                continue
-
-            tmp_path = file_path.with_suffix(file_path.suffix + ".tmp")
-
-            try:
-                start_str = time_interval.strftime("%Y-%m-%dT%H:%M")
-                extent = int(timedelta(days=1).total_seconds())
-                url = f"{self.URL}?python&nohead&logon={self.username}&start={start_str}&extent={extent}&indices=sme"
-
-                logger.debug(f"Downloading data from {url} ...")
-                self._record_url(url)
-
-                response = requests.get(url, timeout=10)
-                response.raise_for_status()
-
-                data = response.text.splitlines()
-                if not data:
-                    raise ValueError("SuperMAG returned an empty response")
-                if data[0].startswith("ERROR"):
-                    err = f"SuperMAG {data[0]}"
-                    raise ValueError(err)
-
-                filename = "index.html"
-                with open(temporary_dir / filename, "w") as file:
-                    file.write("\n".join(data))
-
-                logger.debug("Processing file ...")
-
-                processed_df = self._process_single_file(temporary_dir / filename)
-                processed_df.to_csv(tmp_path, index=True, header=True)
-                tmp_path.replace(file_path)
-
-            except Exception as e:
-                logger.error(f"Failed to process {file_path}: {e}")
-                if tmp_path.exists():
-                    tmp_path.unlink()
-                continue
-
-        rmtree(temporary_dir, ignore_errors=True)
-
-    def _get_processed_file_list(self, start_time: datetime, end_time: datetime) -> Tuple[List, List]:
-        """Get a list of file paths and their corresponding time intervals.
-
-        Returns
-        -------
-        Tuple[List, List]
-            List of file paths and time intervals.
-        """
-
-        file_paths = []
-        time = []
-
-        current_time = start_time.replace(hour=0, minute=0, second=0, microsecond=0)
-        end_time = end_time.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
-
-        while current_time < end_time:
-            file_path = self.data_dir / f"SuperMAG_SME_{current_time.strftime('%Y%m%d')}.csv"
-            file_paths.append(file_path)
-
-            file_time = current_time
-
-            time.append(file_time)
-
-            # Increment the day
-            current_time = current_time + timedelta(days=1)
-
-        return file_paths, time
-
-    def _process_single_file(self, file_path: Path) -> pd.DataFrame:
-        """Process daily SuperMAG SME file into a DataFrame.
-
-        Parameters
-        ----------
-        file_path : Path
-            Path to the file.
-
-        Returns
-        -------
-        pd.DataFrame
-            Processed SuperMAG SME data.
+            Replace complete cached files as well. Defaults to ``False``.
 
         Raises
         ------
         ValueError
-            If no JSON object/array is found in the downloaded file.
+            If the time range is invalid or SuperMAG returns unusable data.
+        requests.RequestException
+            If a request fails. Existing cache files remain untouched.
         """
+        if start_time >= end_time:
+            raise ValueError("start_time must be before end_time")
 
-        with open(file_path, "r") as file:
-            text = file.read()
+        start_time = enforce_utc_timezone(start_time)
+        end_time = enforce_utc_timezone(end_time)
+        self._resolved_urls = []
+        file_paths, time_intervals = self._get_processed_file_list(start_time, end_time)
 
-        match = re.search(r"(\{.*\}|\[.*\])", text, re.S)
-        if match is None:
-            raise ValueError("No JSON object/array found in file")
-        json_text = match.group(1)
-        data = json.loads(json_text)
+        for file_path, time_interval in zip(file_paths, time_intervals, strict=True):
+            if file_path.exists() and not reprocess_files and self._cache_contains(file_path, self._VARIABLES):
+                continue
+            self._download_and_process_single_file(file_path, time_interval)
+
+    def _download_and_process_single_file(self, file_path: Path, time_interval: datetime) -> None:
+        """Download one day and atomically replace its processed cache."""
+        tmp_path = file_path.with_suffix(f"{file_path.suffix}.tmp")
+        params = {
+            "python": "",
+            "nohead": "",
+            "logon": self.username,
+            "start": time_interval.strftime("%Y-%m-%dT%H:%M"),
+            "extent": int(timedelta(days=1).total_seconds()),
+            "indices": ",".join(self._VARIABLES),
+        }
+
+        # Do not log the prepared request URL: it contains the SuperMAG username.
+        logger.debug("Downloading SuperMAG indices for %s", time_interval.date())
+        try:
+            resolved_url = requests.Request("GET", self.URL, params=params).prepare().url
+            if resolved_url is None:
+                raise ValueError("Could not resolve the SuperMAG request URL")
+            self._record_url(resolved_url)
+            response = requests.get(self.URL, params=params, timeout=10)
+            response.raise_for_status()
+            processed_df = self._process_response_text(response.text)
+            processed_df.to_csv(tmp_path, index=True, header=True)
+            tmp_path.replace(file_path)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+    def _get_processed_file_list(self, start_time: datetime, end_time: datetime) -> tuple[list[Path], list[datetime]]:
+        """Return daily cache paths and matching midnight request times."""
+        file_paths = []
+        time_intervals = []
+
+        current_time = start_time.replace(hour=0, minute=0, second=0, microsecond=0)
+        final_midnight = end_time.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+
+        while current_time < final_midnight:
+            file_paths.append(self.data_dir / f"SuperMAG_SME_{current_time:%Y%m%d}.csv")
+            time_intervals.append(current_time)
+            current_time += timedelta(days=1)
+
+        return file_paths, time_intervals
+
+    def _process_single_file(self, file_path: Path) -> pd.DataFrame:
+        """Process a downloaded SuperMAG response stored in ``file_path``."""
+        return self._process_response_text(file_path.read_text())
+
+    def _process_response_text(self, text: str) -> pd.DataFrame:
+        """Parse a SuperMAG indices response into the complete cache schema."""
+        response_text = text.strip()
+        if not response_text:
+            raise ValueError("SuperMAG returned an empty response")
+        if response_text.startswith("ERROR"):
+            first_line = response_text.splitlines()[0]
+            raise ValueError(f"SuperMAG {first_line}")
+
+        try:
+            data = json.loads(response_text)
+        except json.JSONDecodeError as direct_error:
+            # Some server/proxy responses wrap the JSON in surrounding text.
+            match = re.search(r"(\[.*\]|\{.*\})", response_text, re.S)
+            if match is None:
+                raise ValueError("No JSON object or array found in SuperMAG response") from direct_error
+            try:
+                data = json.loads(match.group(1))
+            except json.JSONDecodeError as wrapped_error:
+                raise ValueError("Malformed JSON in SuperMAG response") from wrapped_error
+
+        if isinstance(data, dict):
+            data = [data]
+        if not isinstance(data, list) or not data:
+            raise ValueError("SuperMAG response must contain at least one record")
 
         df = pd.DataFrame(data)
+        required_columns = {"tval", *self._RESPONSE_COLUMNS}
+        missing_columns = sorted(required_columns.difference(df.columns))
+        if missing_columns:
+            raise ValueError(f"SuperMAG response is missing required fields: {', '.join(missing_columns)}")
 
-        df["timestamp"] = pd.to_datetime(df["tval"], unit="s", utc=True)
-        df.index = df["timestamp"]
-        df.drop(columns=["timestamp", "tval"], inplace=True)
-        df = df.rename(columns={"SME": "sme"})
+        timestamps = pd.to_datetime(pd.to_numeric(df["tval"], errors="coerce"), unit="s", utc=True, errors="coerce")
+        if timestamps.isna().any():
+            raise ValueError("SuperMAG response contains an invalid timestamp")
 
-        mask = df["sme"] >= 999998
-        df.loc[mask, "sme"] = np.nan
+        df = df.rename(columns=self._RESPONSE_COLUMNS)
+        for variable in self._VARIABLES:
+            df[variable] = pd.to_numeric(df[variable], errors="coerce")
+            df.loc[df[variable] >= self._FILL_VALUE_THRESHOLD, variable] = np.nan
 
-        return df
+        processed = df.loc[:, self._VARIABLES].copy()
+        processed.index = pd.DatetimeIndex(timestamps, name="timestamp")
+        return processed
 
-    def read(self, start_time: datetime, end_time: datetime, download: bool = False) -> pd.DataFrame:
-        """
-        Read SuperMAG SME data for a given time range.
+    def read(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        download: bool = False,
+        variables: str | Iterable[str] | None = None,
+    ) -> pd.DataFrame:
+        """Read SuperMAG auroral electrojet indices.
 
         Parameters
         ----------
         start_time : datetime
-            Start time of the data to read. Must be timezone-aware.
+            First requested instant. Naive values are interpreted as UTC.
         end_time : datetime
-            End time of the data to read. Must be timezone-aware.
+            Last requested instant. Naive values are interpreted as UTC.
         download : bool, optional
-            Download missing data files on demand. Defaults to False.
+            Download missing files and upgrade incomplete caches. Defaults to
+            ``False``.
+        variables : str | Iterable[str] | None, optional
+            Variables to return. ``None`` preserves the legacy ``sme`` output,
+            ``"all"`` returns ``sme``, ``sml``, and ``smu``, and an ordered
+            name or iterable returns a subset in caller order. Duplicate names
+            are removed after their first occurrence.
 
         Returns
         -------
-        :class:`pandas.DataFrame`
-           SuperMAG SME data.
-        """
+        pandas.DataFrame
+            Selected one-minute indices in nT, followed by ``file_name``.
+            The UTC index covers the requested interval using the reader's
+            established one-minute boundary tolerance.
 
+        Raises
+        ------
+        TypeError
+            If ``variables`` or one of its entries is not a string.
+        ValueError
+            If the interval is invalid, the selection is empty or unknown, or
+            a requested variable is absent from a cache and downloading is
+            disabled.
+
+        Examples
+        --------
+        ``reader.read(start, end)`` returns the legacy SME schema.
+        ``reader.read(start, end, variables="all")`` returns all three indices.
+        ``reader.read(start, end, variables=["smu", "sml"])`` preserves that
+        requested column order.
+        """
+        selected_variables = self._resolve_variables(variables)
         if start_time > end_time:
-            msg = "start_time must be before end_time"
-            logger.error(msg)
-            raise ValueError(msg)
+            raise ValueError("start_time must be before end_time")
 
         start_time = enforce_utc_timezone(start_time)
         end_time = enforce_utc_timezone(end_time)
-
-        file_paths, _ = self._get_processed_file_list(start_time, end_time)
-        t = pd.date_range(
+        if download:
+            self._resolved_urls = []
+        file_paths, time_intervals = self._get_processed_file_list(start_time, end_time)
+        index = pd.date_range(
             datetime(start_time.year, start_time.month, start_time.day),
-            datetime(end_time.year, end_time.month, end_time.day, 23, 59, 00),
+            datetime(end_time.year, end_time.month, end_time.day, 23, 59),
             freq=timedelta(minutes=1),
             tz=timezone.utc,
         )
-        data_out = pd.DataFrame(index=t)
-        data_out["sme"] = np.array([np.nan] * len(t))
-        data_out["file_name"] = np.array([None] * len(t))
+        data_out = pd.DataFrame(index=index, columns=[*selected_variables, "file_name"])
 
-        for file_path in file_paths:
-            if not file_path.exists() and download:
-                self.download_and_process(start_time, end_time)
-
+        for file_path, time_interval in zip(file_paths, time_intervals, strict=True):
             if not file_path.exists():
-                warnings.warn(f"File {file_path} not found")
-                continue
+                if download:
+                    self._download_and_process_single_file(file_path, time_interval)
+                else:
+                    warnings.warn(f"File {file_path} not found")
+                    continue
 
-            df_one_file = self._read_single_file(file_path)
-            data_out = df_one_file.combine_first(data_out)
+            try:
+                df_one_file = self._read_single_file(file_path)
+            except (OSError, ValueError, pd.errors.ParserError) as error:
+                if not download:
+                    raise ValueError(
+                        f"Cannot read SuperMAG cache {file_path}. "
+                        "Re-run with download=True to replace the corrupt file."
+                    ) from error
+                self._download_and_process_single_file(file_path, time_interval)
+                df_one_file = self._read_single_file(file_path)
+
+            required_cache_variables = (
+                self._VARIABLES
+                if any(variable not in self._DEFAULT_VARIABLES for variable in selected_variables)
+                else selected_variables
+            )
+            missing_variables = [
+                variable for variable in required_cache_variables if variable not in df_one_file.columns
+            ]
+            if missing_variables:
+                if not download:
+                    missing = ", ".join(missing_variables)
+                    raise ValueError(
+                        f"SuperMAG cache {file_path} does not contain requested fields: {missing}. "
+                        "Re-run with download=True to upgrade the legacy cache."
+                    )
+                self._download_and_process_single_file(file_path, time_interval)
+                df_one_file = self._read_single_file(file_path)
+
+            selected = df_one_file.loc[:, selected_variables].copy()
+            selected["file_name"] = file_path
+            selected.loc[selected[selected_variables].isna().all(axis=1), "file_name"] = None
+            data_out = selected.combine_first(data_out)
 
         data_out = data_out.truncate(
             before=start_time - timedelta(minutes=0.9999),
             after=end_time + timedelta(minutes=0.9999),
         )
+        return data_out.loc[:, [*selected_variables, "file_name"]]
 
-        return data_out
+    def _resolve_variables(self, variables: str | Iterable[str] | None) -> list[str]:
+        """Validate and normalize a variable selection."""
+        if variables is None:
+            requested = list(self._DEFAULT_VARIABLES)
+        elif isinstance(variables, str):
+            requested = list(self._VARIABLES) if variables == "all" else [variables]
+        else:
+            try:
+                requested = list(variables)
+            except TypeError as error:
+                raise TypeError("variables must be a string, an iterable of strings, or None") from error
 
-    def _read_single_file(self, file_path: Path) -> pd.DataFrame:
-        """Read a daily SuperMAG SME file into a DataFrame.
+        if not requested:
+            raise ValueError("variables must contain at least one variable")
+        if any(not isinstance(variable, str) for variable in requested):
+            raise TypeError("every variables entry must be a string")
 
-        Parameters
-        ----------
-        file_path : Path
-            Path to the file.
+        unknown = list(dict.fromkeys(variable for variable in requested if variable not in self._VARIABLES))
+        if unknown:
+            available = ", ".join(self._VARIABLES)
+            raise ValueError(f"Unknown SuperMAG variables: {', '.join(unknown)}. Available variables: {available}")
 
-        Returns
-        -------
-        pd.DataFrame
-            Data from daily SuperMAG SME file.
-        """
+        return list(dict.fromkeys(requested))
+
+    @staticmethod
+    def _cache_contains(file_path: Path, variables: Iterable[str]) -> bool:
+        """Return whether a readable cache contains valid ``variables``."""
+        try:
+            df = SMESuperMAG._read_single_file(file_path)
+        except (OSError, ValueError, pd.errors.ParserError):
+            return False
+        return set(variables).issubset(df.columns)
+
+    @staticmethod
+    def _read_single_file(file_path: Path) -> pd.DataFrame:
+        """Read a daily processed SuperMAG cache."""
         df = pd.read_csv(file_path)
+        if "timestamp" not in df.columns:
+            raise ValueError("SuperMAG cache has no timestamp column")
 
-        df.index = pd.to_datetime(df["timestamp"], utc=True)
-        df.drop(columns=["timestamp"], inplace=True)
+        timestamps = pd.to_datetime(df.pop("timestamp"), utc=True, errors="coerce")
+        if timestamps.isna().any():
+            raise ValueError("SuperMAG cache contains an invalid timestamp")
+        if df.empty:
+            raise ValueError("SuperMAG cache contains no records")
+
+        for variable in SMESuperMAG._VARIABLES:
+            if variable not in df.columns:
+                continue
+            numeric = pd.to_numeric(df[variable], errors="coerce")
+            if (df[variable].notna() & numeric.isna()).any():
+                raise ValueError(f"SuperMAG cache contains non-numeric {variable} values")
+            df[variable] = numeric
+            df.loc[df[variable] >= SMESuperMAG._FILL_VALUE_THRESHOLD, variable] = np.nan
+
+        df.index = pd.DatetimeIndex(timestamps)
         df.index.name = None
-
-        df["file_name"] = file_path
-        df.loc[df["sme"].isna(), "file_name"] = None
-
         return df

--- a/tests/io/sme/test_sme_supermag.py
+++ b/tests/io/sme/test_sme_supermag.py
@@ -12,7 +12,7 @@ import os
 import warnings
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import numpy as np
 import pandas as pd
@@ -40,6 +40,16 @@ def _response(text: str | None = None) -> Mock:
     response = Mock()
     response.text = text if text is not None else json.dumps(_records())
     response.raise_for_status.return_value = None
+    return response
+
+
+def _http_error_response(status_code: int) -> Mock:
+    response = _response()
+    response.status_code = status_code
+    response.raise_for_status.side_effect = requests.HTTPError(
+        f"HTTP {status_code}",
+        response=response,
+    )
     return response
 
 
@@ -174,7 +184,7 @@ class TestResponseProcessing:
             ("ERROR Invalid user", "SuperMAG ERROR Invalid user"),
             ("not json", "No JSON object or array"),
             ("prefix [{broken}] suffix", "Malformed JSON"),
-            ("[]", "at least one record"),
+            ("[]", "no records"),
             ('"unexpected"', "at least one record"),
         ],
     )
@@ -250,9 +260,132 @@ class TestDownloadAndAtomicCache:
         get.assert_called_once()
         assert list(pd.read_csv(cache_path).columns) == ["timestamp", "sme", "sml", "smu"]
 
+    def test_empty_response_is_retried_until_success(self, reader: SMESuperMAG, tmp_path: Path):
+        with (
+            patch(
+                "swvo.io.sme.supermag.requests.get",
+                side_effect=[_response(""), _response("  \n"), _response()],
+            ) as get,
+            patch("swvo.io.sme.supermag.sleep") as retry_sleep,
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+
+        assert get.call_count == 3
+        assert retry_sleep.call_args_list == [call(1.0), call(2.0)]
+        assert (tmp_path / "SuperMAG_SME_20200101.csv").exists()
+
+    def test_empty_record_array_is_retried(self, reader: SMESuperMAG, tmp_path: Path):
+        with (
+            patch(
+                "swvo.io.sme.supermag.requests.get",
+                side_effect=[_response("[]"), _response()],
+            ) as get,
+            patch("swvo.io.sme.supermag.sleep") as retry_sleep,
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+
+        assert get.call_count == 2
+        retry_sleep.assert_called_once_with(1.0)
+        assert (tmp_path / "SuperMAG_SME_20200101.csv").exists()
+
+    def test_timeout_and_connection_failures_are_retried(self, reader: SMESuperMAG, tmp_path: Path):
+        for error in (requests.Timeout("timeout"), requests.ConnectionError("connection")):
+            cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+            cache_path.unlink(missing_ok=True)
+            with (
+                patch(
+                    "swvo.io.sme.supermag.requests.get",
+                    side_effect=[error, _response()],
+                ) as get,
+                patch("swvo.io.sme.supermag.sleep") as retry_sleep,
+            ):
+                reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+
+            assert get.call_count == 2
+            retry_sleep.assert_called_once_with(1.0)
+            assert cache_path.exists()
+
+    @pytest.mark.parametrize("status_code", [429, 500, 503])
+    def test_retryable_http_status_then_success(self, reader: SMESuperMAG, tmp_path: Path, status_code: int):
+        with (
+            patch(
+                "swvo.io.sme.supermag.requests.get",
+                side_effect=[_http_error_response(status_code), _response()],
+            ) as get,
+            patch("swvo.io.sme.supermag.sleep") as retry_sleep,
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+
+        assert get.call_count == 2
+        retry_sleep.assert_called_once_with(1.0)
+        assert (tmp_path / "SuperMAG_SME_20200101.csv").exists()
+
+    def test_exhausted_transient_day_warns_and_batch_continues(self, reader: SMESuperMAG, tmp_path: Path):
+        responses = [_response("") for _ in range(reader._MAX_DOWNLOAD_ATTEMPTS)]
+        responses.append(_response())
+        with (
+            patch("swvo.io.sme.supermag.requests.get", side_effect=responses) as get,
+            patch("swvo.io.sme.supermag.sleep") as retry_sleep,
+            pytest.warns(
+                RuntimeWarning,
+                match=r"failed after 4 attempts for 1 day.*2020-01-01.*Re-run",
+            ),
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 2))
+
+        assert get.call_count == reader._MAX_DOWNLOAD_ATTEMPTS + 1
+        assert retry_sleep.call_args_list == [call(1.0), call(2.0), call(4.0)]
+        assert not (tmp_path / "SuperMAG_SME_20200101.csv").exists()
+        assert (tmp_path / "SuperMAG_SME_20200102.csv").exists()
+
+    def test_exhausted_empty_response_remains_strict_for_on_demand_read(self, reader: SMESuperMAG):
+        with (
+            patch("swvo.io.sme.supermag.requests.get", return_value=_response("")) as get,
+            patch("swvo.io.sme.supermag.sleep") as retry_sleep,
+            pytest.raises(ValueError, match="empty response"),
+        ):
+            reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 0, 2),
+                download=True,
+                variables="all",
+            )
+
+        assert get.call_count == reader._MAX_DOWNLOAD_ATTEMPTS
+        assert retry_sleep.call_args_list == [call(1.0), call(2.0), call(4.0)]
+
+    def test_invalid_username_is_not_retried(self, reader: SMESuperMAG):
+        with (
+            patch(
+                "swvo.io.sme.supermag.requests.get",
+                return_value=_response("ERROR: Invalid username"),
+            ) as get,
+            patch("swvo.io.sme.supermag.sleep") as retry_sleep,
+            pytest.raises(ValueError, match="Invalid username"),
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+
+        get.assert_called_once()
+        retry_sleep.assert_not_called()
+
+    def test_retry_logging_does_not_expose_username(self, reader: SMESuperMAG, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.DEBUG)
+        error = requests.ConnectionError(f"prepared URL included {TEST_USERNAME}")
+        with (
+            patch(
+                "swvo.io.sme.supermag.requests.get",
+                side_effect=[error, _response()],
+            ),
+            patch("swvo.io.sme.supermag.sleep"),
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+
+        assert "connection failed" in caplog.text
+        assert TEST_USERNAME not in caplog.text
+
     @pytest.mark.parametrize(
         "side_effect",
-        [requests.Timeout("timed out"), requests.HTTPError("server failed")],
+        [requests.Timeout("timed out"), requests.ConnectionError("connection failed")],
     )
     def test_request_failure_preserves_existing_cache_and_cleans_temporary_file(
         self, reader: SMESuperMAG, tmp_path: Path, side_effect: requests.RequestException
@@ -262,22 +395,27 @@ class TestDownloadAndAtomicCache:
         cache_path.write_text(original)
         with (
             patch("swvo.io.sme.supermag.requests.get", side_effect=side_effect),
+            patch("swvo.io.sme.supermag.sleep"),
             pytest.raises(type(side_effect), match=str(side_effect)),
         ):
-            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2), reprocess_files=True)
+            reader._download_and_process_single_file(cache_path, datetime(2020, 1, 1))
         assert cache_path.read_text() == original
         assert not cache_path.with_suffix(".csv.tmp").exists()
 
-    def test_http_status_failure_preserves_existing_cache(self, reader: SMESuperMAG, tmp_path: Path):
+    def test_non_retryable_http_status_preserves_existing_cache(self, reader: SMESuperMAG, tmp_path: Path):
         cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
         cache_path.write_text("timestamp,sme\n2020-01-01T00:00:00+00:00,7\n")
-        response = _response()
-        response.raise_for_status.side_effect = requests.HTTPError("503")
         with (
-            patch("swvo.io.sme.supermag.requests.get", return_value=response),
-            pytest.raises(requests.HTTPError, match="503"),
+            patch(
+                "swvo.io.sme.supermag.requests.get",
+                return_value=_http_error_response(404),
+            ) as get,
+            patch("swvo.io.sme.supermag.sleep") as retry_sleep,
+            pytest.raises(requests.HTTPError, match="404"),
         ):
             reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2), reprocess_files=True)
+        get.assert_called_once()
+        retry_sleep.assert_not_called()
         assert "7" in cache_path.read_text()
         assert not cache_path.with_suffix(".csv.tmp").exists()
 

--- a/tests/io/sme/test_sme_supermag.py
+++ b/tests/io/sme/test_sme_supermag.py
@@ -1,148 +1,512 @@
 # SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
 # SPDX-FileContributor: Dmitrii Gurev
+# SPDX-FileContributor: Simon Mischel
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import shutil
-import warnings
-from datetime import datetime
-from pathlib import Path
-from unittest.mock import patch
+from __future__ import annotations
 
+import json
+import logging
+import os
+import warnings
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import numpy as np
 import pandas as pd
 import pytest
+import requests
 
 from swvo.io.sme import SMESuperMAG
 
-TEST_DATA_DIR = Path("test_data")
-MOCK_DATA_PATH = TEST_DATA_DIR / "mock_sme"
-TEST_USERNAME = "swvo_test"
+TEST_USERNAME = "test:user"
+UTC = timezone.utc
 
 
-class TestSMESuperMAG:
-    @pytest.fixture(autouse=True)
-    def setup_and_cleanup(self):
-        TEST_DATA_DIR.mkdir(exist_ok=True)
-        MOCK_DATA_PATH.mkdir(exist_ok=True)
+def _records(*, include_fill_values: bool = False) -> list[dict[str, float]]:
+    records = [
+        {"tval": 1577836800.0, "SME": 30.0, "SML": -18.0, "SMU": 12.0},
+        {"tval": 1577836860.0, "SME": 35.0, "SML": -20.0, "SMU": 15.0},
+        {"tval": 1577836920.0, "SME": 40.0, "SML": -25.0, "SMU": 15.0},
+    ]
+    if include_fill_values:
+        records[1].update({"SME": 999999.0, "SML": 999998.0, "SMU": 1_000_000.0})
+    return records
 
-        yield
 
-        if TEST_DATA_DIR.exists():
-            shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+def _response(text: str | None = None) -> Mock:
+    response = Mock()
+    response.text = text if text is not None else json.dumps(_records())
+    response.raise_for_status.return_value = None
+    return response
 
-    @pytest.fixture
-    def sme_instance(self):
-        with patch.dict("os.environ", {SMESuperMAG.ENV_VAR_NAME: str(MOCK_DATA_PATH)}):
-            instance = SMESuperMAG(TEST_USERNAME)
-            return instance
 
-    @pytest.fixture
-    def mock_sme_supermag_data(self):
-        return """ [{"tval": 1668816000.000000, "SME": 263.221710},
-{"tval": 1668816060.000000, "SME": 250.118866},
-{"tval": 1668816120.000000, "SME": 234.960663},
-{"tval": 1668816180.000000, "SME": 227.111343},
-{"tval": 1668816240.000000, "SME": 220.567047},
-{"tval": 1668816300.000000, "SME": 213.856384}]
-    """
+def _write_cache(path: Path, columns: tuple[str, ...] = ("sme", "sml", "smu")) -> None:
+    data = pd.DataFrame(_records()).rename(columns={"SME": "sme", "SML": "sml", "SMU": "smu"})
+    data["timestamp"] = pd.to_datetime(data.pop("tval"), unit="s", utc=True)
+    data = data.set_index("timestamp").loc[:, list(columns)]
+    data.to_csv(path)
 
-    def test_initialization_with_env_var(self):
-        with patch.dict("os.environ", {SMESuperMAG.ENV_VAR_NAME: str(MOCK_DATA_PATH)}):
-            sme = SMESuperMAG(TEST_USERNAME)
-            assert sme.data_dir == MOCK_DATA_PATH
 
-    def test_initialization_without_env_var(self):
-        if SMESuperMAG.ENV_VAR_NAME in os.environ:
-            del os.environ[SMESuperMAG.ENV_VAR_NAME]
-        with pytest.raises(ValueError):
+@pytest.fixture
+def reader(tmp_path: Path) -> SMESuperMAG:
+    return SMESuperMAG(TEST_USERNAME, data_dir=tmp_path)
+
+
+class TestInitializationAndFileNames:
+    def test_initialization_with_data_dir(self, tmp_path: Path):
+        reader = SMESuperMAG(TEST_USERNAME, data_dir=tmp_path)
+        assert reader.data_dir == tmp_path
+        assert reader.username == TEST_USERNAME
+
+    def test_initialization_with_env_var(self, tmp_path: Path):
+        with patch.dict(os.environ, {SMESuperMAG.ENV_VAR_NAME: str(tmp_path)}):
+            reader = SMESuperMAG(TEST_USERNAME)
+        assert reader.data_dir == tmp_path
+
+    def test_data_dir_takes_precedence_by_default(self, tmp_path: Path):
+        explicit = tmp_path / "explicit"
+        from_environment = tmp_path / "environment"
+        with patch.dict(os.environ, {SMESuperMAG.ENV_VAR_NAME: str(from_environment)}):
+            reader = SMESuperMAG(TEST_USERNAME, data_dir=explicit)
+        assert reader.data_dir == explicit
+
+    def test_prefer_env_var(self, tmp_path: Path):
+        explicit = tmp_path / "explicit"
+        from_environment = tmp_path / "environment"
+        with patch.dict(os.environ, {SMESuperMAG.ENV_VAR_NAME: str(from_environment)}):
+            reader = SMESuperMAG(TEST_USERNAME, data_dir=explicit, prefer_env_var=True)
+        assert reader.data_dir == from_environment
+
+    def test_initialization_without_data_location(self):
+        with patch.dict(os.environ, {}, clear=True), pytest.raises(ValueError, match="SUPERMAG_STREAM_DIR"):
             SMESuperMAG(TEST_USERNAME)
 
-    def test_get_processed_file_list(self, sme_instance):
-        start_time = datetime(2020, 1, 1)
-        end_time = datetime(2020, 2, 1)
+    def test_get_processed_file_list_preserves_daily_names(self, reader: SMESuperMAG):
+        paths, intervals = reader._get_processed_file_list(datetime(2020, 1, 1), datetime(2020, 1, 2))
+        assert [path.name for path in paths] == ["SuperMAG_SME_20200101.csv", "SuperMAG_SME_20200102.csv"]
+        assert intervals == [datetime(2020, 1, 1), datetime(2020, 1, 2)]
 
-        file_paths, time_intervals = sme_instance._get_processed_file_list(start_time, end_time)
+    def test_url_reflects_encoded_request_after_download(self, reader: SMESuperMAG):
+        assert reader.url == SMESuperMAG.URL
 
-        assert len(file_paths) == 32
-        assert all(str(path).startswith(str(MOCK_DATA_PATH)) for path in file_paths)
-        assert all(path.name.startswith("SuperMAG_SME_") for path in file_paths)
-        assert len(time_intervals) == 32
+        with patch("requests.get", return_value=_response()):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 2))
 
-    def test_download_and_process(self, sme_instance):
-        sme_instance.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 2))
+        assert isinstance(reader.url, list)
+        assert len(reader.url) == 2
+        assert all(url.startswith(f"{SMESuperMAG.URL}?") for url in reader.url)
+        assert all("logon=test%3Auser" in url for url in reader.url)
+        assert all("indices=sme%2Csml%2Csmu" in url for url in reader.url)
 
-        expected_files = list(MOCK_DATA_PATH.glob("**/SuperMAG_SME_*.csv"))
-        print(expected_files)
 
-        assert len(expected_files) == 2
+class TestVariableSelection:
+    @pytest.mark.parametrize(
+        ("variables", "expected"),
+        [
+            (None, ["sme"]),
+            ("all", ["sme", "sml", "smu"]),
+            ("sml", ["sml"]),
+            (["smu", "sme"], ["smu", "sme"]),
+            (("sml", "sml", "sme"), ["sml", "sme"]),
+            ((item for item in ["smu", "sml"]), ["smu", "sml"]),
+        ],
+    )
+    def test_valid_selections(self, reader: SMESuperMAG, variables, expected: list[str]):
+        assert reader._resolve_variables(variables) == expected
 
-        data = pd.read_csv(expected_files[0])
-        assert "sme" in data.columns
+    @pytest.mark.parametrize("variables", [[], (), iter(())])
+    def test_empty_selection(self, reader: SMESuperMAG, variables):
+        with pytest.raises(ValueError, match="at least one"):
+            reader._resolve_variables(variables)
 
-    def test_url_reflects_resolved_request_after_download(self, sme_instance, mocker, mock_sme_supermag_data):
-        assert sme_instance.url == SMESuperMAG.URL
+    @pytest.mark.parametrize("variables", [1, 1.5, object()])
+    def test_invalid_container_type(self, reader: SMESuperMAG, variables):
+        with pytest.raises(TypeError, match="string, an iterable"):
+            reader._resolve_variables(variables)
 
-        mock_response = mocker.Mock()
-        mock_response.text = mock_sme_supermag_data
-        mock_response.raise_for_status = mocker.Mock()
-        mocker.patch("requests.get", return_value=mock_response)
+    @pytest.mark.parametrize("variables", [["sme", 1], [None], {"sme": 1}.values()])
+    def test_non_string_entry(self, reader: SMESuperMAG, variables):
+        with pytest.raises(TypeError, match="every variables entry"):
+            reader._resolve_variables(variables)
 
-        sme_instance.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 2))
+    def test_unknown_names_report_available_names(self, reader: SMESuperMAG):
+        with pytest.raises(ValueError, match=r"Unknown SuperMAG variables: smx.*sme, sml, smu"):
+            reader._resolve_variables(["smx", "smx"])
 
-        assert sme_instance.url != SMESuperMAG.URL
-        assert isinstance(sme_instance.url, list)
-        assert all(
-            url.startswith(SMESuperMAG.URL + f"?python&nohead&logon={TEST_USERNAME}") for url in sme_instance.url
+
+class TestResponseProcessing:
+    def test_complete_response_schema_and_utc_index(self, reader: SMESuperMAG):
+        result = reader._process_response_text(json.dumps(_records()))
+        assert list(result.columns) == ["sme", "sml", "smu"]
+        assert isinstance(result.index, pd.DatetimeIndex)
+        assert str(result.index.tz) == "UTC"
+        assert result.index.name == "timestamp"
+        expected_index = pd.date_range("2020-01-01T00:00:00Z", periods=3, freq="min", name="timestamp")
+        assert result.index.tolist() == expected_index.tolist()
+        np.testing.assert_allclose(result["sme"], result["smu"] - result["sml"])
+
+    def test_fill_values_are_masked_for_every_variable(self, reader: SMESuperMAG):
+        result = reader._process_response_text(json.dumps(_records(include_fill_values=True)))
+        assert result.iloc[1].isna().all()
+        assert result.iloc[0].notna().all()
+
+    def test_non_numeric_measurement_is_masked(self, reader: SMESuperMAG):
+        records = _records()
+        records[0]["SML"] = "missing"  # type: ignore[assignment]
+        result = reader._process_response_text(json.dumps(records))
+        assert pd.isna(result.iloc[0]["sml"])
+
+    def test_single_json_object_is_supported(self, reader: SMESuperMAG):
+        result = reader._process_response_text(json.dumps(_records()[0]))
+        assert len(result) == 1
+
+    def test_wrapped_json_is_supported(self, reader: SMESuperMAG):
+        result = reader._process_response_text(f"response follows:\n{json.dumps(_records())}\nend")
+        assert len(result) == 3
+
+    @pytest.mark.parametrize(
+        ("response_text", "message"),
+        [
+            ("", "empty response"),
+            ("ERROR Invalid user", "SuperMAG ERROR Invalid user"),
+            ("not json", "No JSON object or array"),
+            ("prefix [{broken}] suffix", "Malformed JSON"),
+            ("[]", "at least one record"),
+            ('"unexpected"', "at least one record"),
+        ],
+    )
+    def test_invalid_responses(self, reader: SMESuperMAG, response_text: str, message: str):
+        with pytest.raises(ValueError, match=message):
+            reader._process_response_text(response_text)
+
+    @pytest.mark.parametrize("missing_field", ["tval", "SME", "SML", "SMU"])
+    def test_missing_response_fields(self, reader: SMESuperMAG, missing_field: str):
+        records = _records()
+        for record in records:
+            del record[missing_field]
+        with pytest.raises(ValueError, match=missing_field):
+            reader._process_response_text(json.dumps(records))
+
+    def test_invalid_timestamp(self, reader: SMESuperMAG):
+        records = _records()
+        records[0]["tval"] = "not-a-time"  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="invalid timestamp"):
+            reader._process_response_text(json.dumps(records))
+
+    def test_file_processor_uses_same_parser(self, reader: SMESuperMAG, tmp_path: Path):
+        response_path = tmp_path / "response.txt"
+        response_path.write_text(json.dumps(_records()))
+        result = reader._process_single_file(response_path)
+        assert list(result.columns) == ["sme", "sml", "smu"]
+
+
+class TestDownloadAndAtomicCache:
+    def test_exact_encoded_request_parameters_and_complete_cache(
+        self, reader: SMESuperMAG, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        caplog.set_level(logging.DEBUG)
+        with patch("swvo.io.sme.supermag.requests.get", return_value=_response()) as get:
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+
+        get.assert_called_once_with(
+            "https://supermag.jhuapl.edu/services/indices.php",
+            params={
+                "python": "",
+                "nohead": "",
+                "logon": TEST_USERNAME,
+                "start": "2020-01-01T00:00",
+                "extent": 86400,
+                "indices": "sme,sml,smu",
+            },
+            timeout=10,
         )
+        cache = pd.read_csv(tmp_path / "SuperMAG_SME_20200101.csv")
+        assert list(cache.columns) == ["timestamp", "sme", "sml", "smu"]
+        assert TEST_USERNAME not in caplog.text
+        assert not list(tmp_path.glob("*.tmp"))
 
-    def test_process_single_file(self, sme_instance, mock_sme_supermag_data):
-        test_file = MOCK_DATA_PATH / "test_sme.txt"
-        test_file.parent.mkdir(exist_ok=True)
+    def test_complete_cache_is_not_downloaded(self, reader: SMESuperMAG, tmp_path: Path):
+        _write_cache(tmp_path / "SuperMAG_SME_20200101.csv")
+        with patch("swvo.io.sme.supermag.requests.get") as get:
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+        get.assert_not_called()
 
-        with open(test_file, "w") as f:
-            f.write(mock_sme_supermag_data)
+    def test_reprocess_replaces_complete_cache(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        _write_cache(cache_path)
+        with patch("swvo.io.sme.supermag.requests.get", return_value=_response()) as get:
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2), reprocess_files=True)
+        get.assert_called_once()
+        assert list(pd.read_csv(cache_path).columns) == ["timestamp", "sme", "sml", "smu"]
 
-        data = sme_instance._process_single_file(test_file)
+    def test_legacy_cache_is_upgraded(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        _write_cache(cache_path, ("sme",))
+        with patch("swvo.io.sme.supermag.requests.get", return_value=_response()) as get:
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+        get.assert_called_once()
+        assert list(pd.read_csv(cache_path).columns) == ["timestamp", "sme", "sml", "smu"]
 
-        assert isinstance(data, pd.DataFrame)
-        assert "sme" in data.columns
-        assert len(data) == 6
+    @pytest.mark.parametrize(
+        "side_effect",
+        [requests.Timeout("timed out"), requests.HTTPError("server failed")],
+    )
+    def test_request_failure_preserves_existing_cache_and_cleans_temporary_file(
+        self, reader: SMESuperMAG, tmp_path: Path, side_effect: requests.RequestException
+    ):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        original = "timestamp,sme\n2020-01-01T00:00:00+00:00,7\n"
+        cache_path.write_text(original)
+        with (
+            patch("swvo.io.sme.supermag.requests.get", side_effect=side_effect),
+            pytest.raises(type(side_effect), match=str(side_effect)),
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2), reprocess_files=True)
+        assert cache_path.read_text() == original
+        assert not cache_path.with_suffix(".csv.tmp").exists()
 
-    def test_read_with_no_data(self, sme_instance):
-        start_time = datetime(2020, 1, 1)
-        end_time = datetime(2020, 1, 10)
+    def test_http_status_failure_preserves_existing_cache(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        cache_path.write_text("timestamp,sme\n2020-01-01T00:00:00+00:00,7\n")
+        response = _response()
+        response.raise_for_status.side_effect = requests.HTTPError("503")
+        with (
+            patch("swvo.io.sme.supermag.requests.get", return_value=response),
+            pytest.raises(requests.HTTPError, match="503"),
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2), reprocess_files=True)
+        assert "7" in cache_path.read_text()
+        assert not cache_path.with_suffix(".csv.tmp").exists()
 
-        with warnings.catch_warnings(record=True) as w:
-            df = sme_instance.read(start_time, end_time, download=False)
+    def test_parse_failure_preserves_existing_cache(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        cache_path.write_text("timestamp,sme\n2020-01-01T00:00:00+00:00,7\n")
+        with (
+            patch("swvo.io.sme.supermag.requests.get", return_value=_response("malformed")),
+            pytest.raises(ValueError, match="No JSON"),
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2), reprocess_files=True)
+        assert "7" in cache_path.read_text()
+        assert not cache_path.with_suffix(".csv.tmp").exists()
 
-            assert "SuperMAG_SME_20200110.csv not found" in str(w[-1].message)
-            assert isinstance(df, pd.DataFrame)
-            assert len(df) == 9 * 24 * 60 + 1
-            assert all(df["sme"].isna())
-            assert all(df["file_name"].isnull())
+    def test_write_failure_preserves_existing_cache(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        cache_path.write_text("timestamp,sme\n2020-01-01T00:00:00+00:00,7\n")
+        with (
+            patch("swvo.io.sme.supermag.requests.get", return_value=_response()),
+            patch.object(pd.DataFrame, "to_csv", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2), reprocess_files=True)
+        assert "7" in cache_path.read_text()
+        assert not cache_path.with_suffix(".csv.tmp").exists()
 
-    def test_read_invalid_time_range(self, sme_instance):
-        start_time = datetime(2020, 12, 31)
-        end_time = datetime(2020, 1, 1)
+    def test_download_rejects_equal_or_reversed_ranges(self, reader: SMESuperMAG):
+        with pytest.raises(ValueError, match="before"):
+            reader.download_and_process(datetime(2020, 1, 1), datetime(2020, 1, 1))
+        with pytest.raises(ValueError, match="before"):
+            reader.download_and_process(datetime(2020, 1, 2), datetime(2020, 1, 1))
 
+
+class TestReadAndCacheCompatibility:
+    def test_legacy_default_schema_and_values(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        _write_cache(cache_path, ("sme",))
+        result = reader.read(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+        assert list(result.columns) == ["sme", "file_name"]
+        assert len(result) == 3
+        assert result["sme"].tolist() == [30.0, 35.0, 40.0]
+        assert result["file_name"].eq(cache_path).all()
+
+    @pytest.mark.parametrize(
+        ("variables", "columns"),
+        [
+            ("all", ["sme", "sml", "smu", "file_name"]),
+            ("sml", ["sml", "file_name"]),
+            (["smu", "sme"], ["smu", "sme", "file_name"]),
+            (["sml", "sml", "sme"], ["sml", "sme", "file_name"]),
+        ],
+    )
+    def test_requested_output_order(self, reader: SMESuperMAG, tmp_path: Path, variables, columns: list[str]):
+        _write_cache(tmp_path / "SuperMAG_SME_20200101.csv")
+        result = reader.read(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2), variables=variables)
+        assert list(result.columns) == columns
+
+    def test_utc_conversion_and_interval_boundaries(self, reader: SMESuperMAG, tmp_path: Path):
+        _write_cache(tmp_path / "SuperMAG_SME_20200101.csv")
+        plus_one = timezone(timedelta(hours=1))
+        result = reader.read(
+            datetime(2020, 1, 1, 1, 1, tzinfo=plus_one),
+            datetime(2020, 1, 1, 1, 2, tzinfo=plus_one),
+        )
+        assert result.index.tolist() == [
+            pd.Timestamp("2020-01-01T00:01:00Z"),
+            pd.Timestamp("2020-01-01T00:02:00Z"),
+        ]
+        assert str(result.index.tz) == "UTC"
+
+    def test_missing_files_warn_and_return_default_nan_schema(self, reader: SMESuperMAG):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = reader.read(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+        assert list(result.columns) == ["sme", "file_name"]
+        assert len(result) == 3
+        assert result.isna().all().all()
+        assert "SuperMAG_SME_20200101.csv not found" in str(caught[-1].message)
+
+    def test_missing_cache_is_downloaded_on_demand(self, reader: SMESuperMAG):
+        with patch("swvo.io.sme.supermag.requests.get", return_value=_response()) as get:
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 0, 2),
+                download=True,
+                variables="all",
+            )
+        get.assert_called_once()
+        assert result[["sme", "sml", "smu"]].notna().all().all()
+
+    def test_legacy_cache_reports_missing_fields_without_download(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        _write_cache(cache_path, ("sme",))
+        with pytest.raises(ValueError, match=r"sml, smu.*download=True.*upgrade"):
+            reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 0, 2),
+                variables=["sml", "smu"],
+            )
+        assert list(pd.read_csv(cache_path).columns) == ["timestamp", "sme"]
+
+    def test_legacy_cache_is_upgraded_for_expanded_read(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        _write_cache(cache_path, ("sme",))
+        with patch("swvo.io.sme.supermag.requests.get", return_value=_response()) as get:
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 0, 2),
+                download=True,
+                variables=["smu", "sml"],
+            )
+        get.assert_called_once()
+        assert list(result.columns) == ["smu", "sml", "file_name"]
+        assert list(pd.read_csv(cache_path).columns) == ["timestamp", "sme", "sml", "smu"]
+
+    def test_partially_expanded_cache_still_requires_complete_schema(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        _write_cache(cache_path, ("sme", "sml"))
+        with pytest.raises(ValueError, match=r"smu.*download=True.*upgrade"):
+            reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 0, 2),
+                variables="sml",
+            )
+
+    def test_partially_expanded_cache_is_upgraded_when_download_enabled(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        _write_cache(cache_path, ("sme", "sml"))
+        with patch("swvo.io.sme.supermag.requests.get", return_value=_response()) as get:
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 0, 2),
+                download=True,
+                variables="sml",
+            )
+        get.assert_called_once()
+        assert list(result.columns) == ["sml", "file_name"]
+        assert list(pd.read_csv(cache_path).columns) == ["timestamp", "sme", "sml", "smu"]
+
+    def test_complete_cache_never_requires_credentials_during_read(self, reader: SMESuperMAG, tmp_path: Path):
+        _write_cache(tmp_path / "SuperMAG_SME_20200101.csv")
+        with patch("swvo.io.sme.supermag.requests.get") as get:
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 0, 2),
+                download=True,
+                variables="all",
+            )
+        get.assert_not_called()
+        assert result[["sme", "sml", "smu"]].notna().all().all()
+
+    def test_corrupt_cache_reports_remediation(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        cache_path.write_text("not,a,valid,cache\n")
+        with pytest.raises(ValueError, match=r"Cannot read.*download=True.*corrupt"):
+            reader.read(datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 2))
+
+    def test_corrupt_cache_is_replaced_when_download_enabled(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        cache_path.write_text("not,a,valid,cache\n")
+        with patch("swvo.io.sme.supermag.requests.get", return_value=_response()):
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 0, 2),
+                download=True,
+                variables="all",
+            )
+        assert result[["sme", "sml", "smu"]].notna().all().all()
+        assert list(pd.read_csv(cache_path).columns) == ["timestamp", "sme", "sml", "smu"]
+
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            "timestamp,sme,sml,smu\n",
+            "timestamp,sme,sml,smu\n2020-01-01T00:00:00Z,invalid,-5,10\n",
+            "timestamp,sme,sml,smu\nnot-a-time,15,-5,10\n",
+        ],
+    )
+    def test_complete_headers_do_not_hide_corrupt_cache(self, reader: SMESuperMAG, tmp_path: Path, contents: str):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        cache_path.write_text(contents)
+        with pytest.raises(ValueError, match=r"Cannot read.*download=True.*corrupt"):
+            reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 0, 2),
+                variables="all",
+            )
+
+    def test_fill_values_in_existing_cache_are_masked(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        cache_path.write_text("timestamp,sme,sml,smu\n2020-01-01T00:00:00Z,999999,999998,1000000\n")
+        result = reader.read(datetime(2020, 1, 1), datetime(2020, 1, 1), variables="all")
+        assert result[["sme", "sml", "smu"]].isna().all().all()
+        assert pd.isna(result.iloc[0]["file_name"])
+
+    def test_provenance_follows_selected_variables(self, reader: SMESuperMAG, tmp_path: Path):
+        cache_path = tmp_path / "SuperMAG_SME_20200101.csv"
+        data = pd.DataFrame(
+            {
+                "sme": [np.nan],
+                "sml": [-5.0],
+                "smu": [10.0],
+            },
+            index=pd.DatetimeIndex(["2020-01-01T00:00:00Z"], name="timestamp"),
+        )
+        data.to_csv(cache_path)
+        sme = reader.read(datetime(2020, 1, 1), datetime(2020, 1, 1), variables="sme")
+        all_indices = reader.read(datetime(2020, 1, 1), datetime(2020, 1, 1), variables="all")
+        assert pd.isna(sme.iloc[0]["file_name"])
+        assert all_indices.iloc[0]["file_name"] == cache_path
+
+    def test_read_rejects_reversed_range(self, reader: SMESuperMAG):
         with pytest.raises(ValueError, match="start_time must be before end_time"):
-            sme_instance.read(start_time, end_time)
+            reader.read(datetime(2020, 1, 2), datetime(2020, 1, 1))
 
-    def test_read_with_existing_data(self, sme_instance):
-        sample_data = pd.DataFrame(
-            {"sme": range(1441)}, index=pd.date_range(start="2020-01-01", end="2020-01-02", freq="min")
-        )
-        sample_data.index.name = "timestamp"
 
-        file_path = MOCK_DATA_PATH / "SuperMAG_SME_20200101.csv"
-        sample_data.to_csv(file_path, index=True)
-
-        start_time = datetime(2020, 1, 1, 12)
-        end_time = datetime(2020, 1, 1, 18)
-
-        data = sme_instance.read(start_time, end_time)
-
-        assert isinstance(data, pd.DataFrame)
-        assert len(data) > 0
-        assert all(col in data.columns for col in ["sme"])
+@pytest.mark.skipif(
+    os.environ.get("SWVO_RUN_LIVE_TESTS") != "1" or not os.environ.get("SUPERMAG_USERNAME"),
+    reason="set SWVO_RUN_LIVE_TESTS=1 and SUPERMAG_USERNAME to run the authenticated smoke test",
+)
+def test_live_authenticated_historical_smoke(tmp_path: Path):
+    """Exercise one historical day against SuperMAG only when explicitly enabled."""
+    reader = SMESuperMAG(os.environ["SUPERMAG_USERNAME"], data_dir=tmp_path)
+    result = reader.read(
+        datetime(2020, 1, 1, tzinfo=UTC),
+        datetime(2020, 1, 1, 0, 2, tzinfo=UTC),
+        download=True,
+        variables="all",
+    )
+    assert list(result.columns) == ["sme", "sml", "smu", "file_name"]
+    assert result[["sme", "sml", "smu"]].notna().all().all()
+    np.testing.assert_allclose(result["sme"], result["smu"] - result["sml"], rtol=0, atol=1e-3)


### PR DESCRIPTION
## Summary

Extend `SMESuperMAG` to support the complete standard SuperMAG auroral electrojet trio: SME, SML, and SMU.

The existing behavior remains backward compatible: calling `read()` without a variable selection continues to return only `sme` and `file_name`.

## Motivation

SWVO previously exposed only SME, although SuperMAG supplies SME, SML, and SMU together and all three are commonly needed for auroral electrojet and substorm analyses.

During authenticated historical testing, SuperMAG also intermittently returned an empty response for an otherwise valid day. Repeating the same request succeeded. The downloader has therefore been hardened so that one transient response does not unnecessarily terminate a long historical download.

## API

`SMESuperMAG.read()` now accepts a `variables` argument:

```python
reader.read(start, end)
# sme, file_name

reader.read(start, end, variables="all")
# sme, sml, smu, file_name

reader.read(start, end, variables=["smu", "sml"])
# smu, sml, file_name
```

A single variable or ordered iterable is supported. Duplicate variables are removed while preserving their first occurrence. Empty, non-string, and unknown selections produce descriptive errors.

## Compatibility and caching

- The class name, import path, constructor, environment variable, daily filenames, time-window behavior, and default SME-only schema are unchanged.
- New downloads request and cache SME, SML, and SMU together.
- Existing SME-only caches remain valid for default reads.
- When SML or SMU is requested from a legacy cache:
  - `download=False` reports the missing fields and explains how to upgrade the cache.
  - `download=True` atomically replaces the incomplete daily cache with a complete file.
- Corrupt caches follow the same remediation policy.
- Existing cache files remain untouched if downloading, parsing, or writing fails.
- The current `BaseIO.url` interface is preserved; resolved SuperMAG request URLs use encoded parameters.

## Transient download handling

The downloader now treats the following conditions as transient:

- Empty response bodies or empty JSON record arrays.
- Request timeouts and connection failures.
- HTTP 429 and HTTP 5xx responses.

Each affected day is attempted up to four times, with waits of one, two, and four seconds.

After all attempts are exhausted:

- A historical `download_and_process()` operation records the failed date, continues with subsequent days, and emits a summary warning.
- An on-demand `read(..., download=True)` remains strict and raises the final failure because the requested data cannot be returned.

Permanent failures, including invalid SuperMAG credentials, malformed data, and other HTTP 4xx responses, are not retried.

Requests use encoded parameters, and prepared URLs containing the SuperMAG username are not logged.

## Data handling

- All three variables use nanotesla units.
- SuperMAG fill values are converted to `NaN`.
- Returned indices remain timezone-aware UTC.
- Requested column ordering and `file_name` provenance are preserved.
- Per-file temporary output and atomic replacement remove the previous shared temporary-directory dependency.

## Documentation

A dedicated [SuperMAG electrojet guide](https://github.com/Simon060899/SWVO/blob/feature/supermag-sml-smu/docs/supermag_indices.rst) documents:

- SME, SML, and SMU definitions and units.
- Authentication and credential handling.
- Variable-selection examples.
- Cache compatibility and upgrades.
- Transient and permanent failure behavior.
- Time coverage and error handling.
- SuperMAG data references and acknowledgment guidance.

The README and Sphinx user-guide index have also been updated.

## Verification

Local verification:

- Targeted SuperMAG tests: 81 passed; one opt-in live test skipped in the deterministic run.
- Authenticated historical SuperMAG live test: passed separately.
- Complete `tests/io` suite: 688 passed, 14 skipped, 0 failed.
  - Eleven SIDC tests were skipped because the external service was unavailable.
  - Two OMNI live tests are opt-in.
  - The one SuperMAG live test is opt-in and passed separately.
- Ruff lint and formatting: passed.
- Ty type checking: passed.
- Strict isolated Sphinx build of the SuperMAG guide: passed without warnings.
- REUSE compliance: passed.

The fork’s GitHub Actions matrix passed on Ubuntu and macOS with Python 3.11, 3.12, 3.13, and 3.14.
