### PR TITLE
Add SuperMAG substorm onset catalogues

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ This package provides tools to read, process, and analyze several key solar and 
   - **Sources & Classes:**
     - SuperMAG: `SMESuperMAG`
 
+- **Substorm-onset events**:
+  Sparse onset catalogues identified from SuperMAG SML or auroral images. The available techniques are Newell, Forsyth/SOPHIE, Ohtani, Frey, and Liou.
+  - **Sources & Classes:**
+    - SuperMAG: `SubstormsSuperMAG`
+
 - **Solar Wind Parameters**:  
   Access to solar wind data (speed, density, magnetic field components) from various spacecraft. Essential for solar-terrestrial interaction studies.
   - **Sources & Classes:**
@@ -115,6 +120,27 @@ per day and continue past an unavailable day with a dated warning. See the
 [SuperMAG electrojet guide](https://swvo.readthedocs.io/en/latest/supermag_indices.html)
 for authentication, cache compatibility, error handling, data references, and
 acknowledgement guidance.
+
+## SuperMAG substorm-onset catalogues
+
+`SubstormsSuperMAG` retrieves one of the five scientifically distinct onset
+catalogues distributed by SuperMAG. Newell is the default, and `sophie` is
+accepted as an alias for the official `forsyth` identifier:
+
+```python
+from swvo.io.substorms import SubstormsSuperMAG
+
+reader = SubstormsSuperMAG(username, data_dir=cache_directory)
+newell = reader.read(start, end, download=True)
+sophie = reader.read(start, end, download=True, catalog="sophie")
+```
+
+Results contain onset location, canonical catalogue name, UTC indexing, and
+local-file provenance. Annual self-documented caches retain SuperMAG revision
+and acknowledgement information. See the
+[SuperMAG substorm catalogue guide](https://swvo.readthedocs.io/en/latest/supermag_substorms.html)
+for catalogue differences, coverage, location interpretation, caching,
+revisions, reliability, and publication requirements.
 
 ## Expanded OMNI data access
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,5 +30,6 @@ User Guide
    Examples <examples/solar_wind_example>
    Complete OMNI variables <omni_variables>
    SuperMAG electrojet indices <supermag_indices>
+   SuperMAG substorm-onset catalogues <supermag_substorms>
    Changelog <changelog>
    Contributing Guide <CONTRIBUTING>

--- a/docs/supermag_substorms.rst
+++ b/docs/supermag_substorms.rst
@@ -1,0 +1,271 @@
+.. SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
+.. SPDX-FileContributor: Simon Mischel
+..
+.. SPDX-License-Identifier: Apache-2.0
+
+SuperMAG substorm-onset catalogues
+==================================
+
+The :class:`swvo.io.substorms.SubstormsSuperMAG` reader downloads and reads
+the five substorm-onset catalogues currently distributed through the SuperMAG
+Products service. These data are sparse event records rather than a continuous
+time series: every row represents an identified onset.
+
+The catalogues implement different scientific definitions. They should be
+selected and compared deliberately rather than merged into a single
+``"all"`` result.
+
+Quick start
+-----------
+
+Register on the `SuperMAG website <https://supermag.jhuapl.edu/>`_ and supply
+the username at runtime:
+
+.. code-block:: python
+
+   import os
+   from datetime import datetime, timezone
+   from pathlib import Path
+
+   from swvo.io.substorms import SubstormsSuperMAG
+
+   reader = SubstormsSuperMAG(
+       username=os.environ["SUPERMAG_USERNAME"],
+       data_dir=Path("./supermag_data"),
+   )
+
+   start = datetime(2001, 1, 1, tzinfo=timezone.utc)
+   end = datetime(2001, 1, 2, tzinfo=timezone.utc)
+
+   events = reader.read(start, end, download=True)
+   # The default catalogue is "newell".
+
+Use ``catalog`` to select another onset list:
+
+.. code-block:: python
+
+   sophie_onsets = reader.read(
+       start,
+       end,
+       download=True,
+       catalog="sophie",
+   )
+   # "sophie" is normalized to SuperMAG's canonical "forsyth" identifier.
+
+Only one catalogue is returned by each call. This prevents events derived by
+different techniques from being combined or de-duplicated without an explicit
+scientific decision by the caller.
+
+Available catalogues
+--------------------
+
+The registry can be inspected without accessing the network:
+
+.. code-block:: python
+
+   metadata = reader.available_catalogs()
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 20 30 18 20
+
+   * - Name
+     - Reference
+     - Method
+     - SuperMAG coverage
+     - Update behavior
+   * - ``newell``
+     - Newell and Gjerloev (2011)
+     - Automated onset identification from changes in one-minute SML
+     - 1969-current
+     - Continuously revised
+   * - ``forsyth``
+     - Forsyth et al. (2015), SOPHIE
+     - SOPHIE expansion-phase onset identification from filtered SML
+     - 1969-current
+     - Continuously revised
+   * - ``ohtani``
+     - Ohtani and Gjerloev (2020)
+     - Strict SML criteria for high-confidence isolated substorms
+     - 1969-current
+     - Continuously revised
+   * - ``frey``
+     - Frey et al. (2004 and 2006)
+     - Auroral onsets identified in IMAGE-FUV observations
+     - 19 May 2000-31 December 2002
+     - Final, with observing gaps
+   * - ``liou``
+     - Liou (2010)
+     - Auroral breakups identified in Polar UVI observations
+     - Parts of 1996-2000 and 2007
+     - Final, with observing gaps
+
+Canonical names are case-insensitive. Documented aliases include ``sophie``
+for ``forsyth``, ``newell_gjerloev`` for ``newell``,
+``ohtani_gjerloev`` for ``ohtani``, and ``frey_mende`` for ``frey``.
+Spaces and hyphens in aliases are normalized to underscores. Empty,
+non-string, and unknown catalogue selections raise a descriptive exception
+before any file or network access.
+
+Output schema
+-------------
+
+The returned :class:`pandas.DataFrame` has a timezone-aware UTC
+``DatetimeIndex`` named ``onset`` and the following columns:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 18 66
+
+   * - Column
+     - Unit/type
+     - Meaning
+   * - ``mlt``
+     - hours
+     - Magnetic local time associated with the onset. SuperMAG serves the
+       Liou values in degrees despite labelling the field ``MLT``; SWVO
+       normalizes them to hours using 15 degrees per hour.
+   * - ``mlat``
+     - degrees
+     - Magnetic latitude associated with the onset
+   * - ``glon``
+     - degrees
+     - Geographic longitude associated with the onset
+   * - ``glat``
+     - degrees
+     - Geographic latitude associated with the onset
+   * - ``catalog``
+     - string
+     - Canonical catalogue identifier
+   * - ``file_name``
+     - path
+     - Local source-file provenance
+
+Both interval boundaries are inclusive. A valid interval with no identified
+events returns an empty DataFrame with the same columns and a UTC index. It is
+not treated as a download failure.
+
+Location interpretation
+-----------------------
+
+For the ``newell``, ``forsyth``, and ``ohtani`` lists, SuperMAG states that
+the onset location is the location of the station contributing to SML at that
+time. It is therefore a station-based location proxy and should not
+automatically be interpreted as the physical auroral breakup location.
+
+The ``frey`` and ``liou`` coordinates are instead derived from auroral image
+observations. Their interpretation, coverage, and selection effects differ
+from the index-derived catalogues.
+
+The original Liou files distributed through SuperMAG store their
+``<mlt>`` values in degrees. This is evident from values such as ``337.9`` and
+is consistent with the approximately 22.6-hour mean reported by Liou (2010)
+after division by 15 degrees per hour. SWVO performs that conversion in the
+returned DataFrame while retaining the unmodified self-documented source file
+in the cache.
+
+SOPHIE onset list versus complete phase classification
+------------------------------------------------------
+
+The SuperMAG ``forsyth`` product exposed by this reader contains onset time
+and location records with the common five-field event schema. It does not
+contain the complete minute-by-minute SOPHIE growth, expansion, and recovery
+phase classification described by Forsyth et al. (2015).
+
+Implementing the complete SOPHIE method would be a separate derived-data
+feature requiring its filtering, percentile thresholds, phase corrections,
+and enhanced-convection checks to be reproduced and scientifically validated.
+
+Cache layout and revisions
+--------------------------
+
+The reader stores one self-documented ASCII response per catalogue and year:
+
+.. code-block:: text
+
+   <SUPERMAG_STREAM_DIR>/
+     substorms/
+       newell/
+         SuperMAG_SUBSTORMS_NEWELL_2001.txt
+       forsyth/
+         SuperMAG_SUBSTORMS_FORSYTH_2001.txt
+
+Annual files minimize requests for these sparse data. The exact downloaded
+response is retained after validation, preserving SuperMAG's data revision,
+database generation time, download time, caveats, acknowledgement text, and
+references. ``file_name`` connects each returned event to that provenance.
+
+The three index-derived catalogues are revised when SuperMAG's underlying
+holdings change. ``download=True`` retrieves missing files but preserves
+existing ones for reproducibility. Explicitly refresh a cached interval when
+the latest catalogue revision is required:
+
+.. code-block:: python
+
+   reader.download_and_process(
+       start,
+       end,
+       reprocess_files=True,
+       catalog="newell",
+   )
+
+Every response is parsed and validated before it atomically replaces the
+target file. A request, validation, or write failure leaves an existing cache
+untouched and removes the temporary file. A corrupt cache produces remediation
+guidance when downloads are disabled and is replaced when ``download=True``.
+
+Authentication and privacy
+--------------------------
+
+The SuperMAG Products page asks users to log on before downloading. SWVO sends
+the registered username as an encoded request parameter. The username is not
+stored in a cache, included in logs, or exposed through the reader's ``url``
+provenance property. Keep it in a local environment variable and never commit
+it to source control.
+
+Reliability and error handling
+------------------------------
+
+Zero-byte responses, connection failures, timeouts, HTTP ``429``, and HTTP
+``5xx`` responses are retried up to four times with bounded exponential
+backoff. A well-formed response containing no event rows is valid and is
+cached without retrying.
+
+An explicit SuperMAG ``ERROR`` response, non-retryable HTTP error, malformed
+table, non-numeric field, or invalid onset time is reported clearly. Historical
+batch downloads continue to later years after exhausting retries for a
+transiently failing year and emit a warning listing the failed years. An
+on-demand :meth:`~swvo.io.substorms.SubstormsSuperMAG.read` remains strict
+when its required download cannot be completed.
+
+Sources, limitations, and acknowledgement
+-----------------------------------------
+
+SuperMAG emphasizes that all onset techniques have limitations and that users
+must understand the assumptions of the selected list. Before publication,
+consult the current:
+
+* `SuperMAG Products overview and catalogue acknowledgements
+  <https://supermag.jhuapl.edu/products/?tab=about>`_;
+* `derivation descriptions
+  <https://supermag.jhuapl.edu/products/?tab=description>`_;
+* `download rules of the road
+  <https://supermag.jhuapl.edu/products/?tab=download>`_.
+
+SuperMAG states that its data and derived products are subject to fair-use
+restrictions and must not be redistributed. It requests the catalogue-specific
+acknowledgement and reference and, when an onset list is central to a study,
+an offer of co-authorship to the authors of the selected technique.
+
+The principal catalogue references are:
+
+* `Newell and Gjerloev (2011)
+  <https://doi.org/10.1029/2011JA016779>`_;
+* `Forsyth et al. (2015)
+  <https://doi.org/10.1002/2015JA021343>`_;
+* `Ohtani and Gjerloev (2020)
+  <https://doi.org/10.1029/2020JA027902>`_;
+* `Frey et al. (2004)
+  <https://doi.org/10.1029/2004JA010607>`_;
+* `Liou (2010)
+  <https://doi.org/10.1029/2010JA015578>`_.

--- a/swvo/io/__init__.py
+++ b/swvo/io/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 GFZ Helmholtz Centre for Geosciences
+# SPDX-FileContributor: Simon Mischel
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,5 +13,6 @@ from swvo.io import (
     RBMDataSet as RBMDataSet,
     solar_wind as solar_wind,
     sme as sme,
+    substorms as substorms,
 )
 from swvo.io.base import BaseIO as BaseIO

--- a/swvo/io/substorms/__init__.py
+++ b/swvo/io/substorms/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
+# SPDX-FileContributor: Simon Mischel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SuperMAG substorm-onset catalogue access."""
+
+from swvo.io.substorms.catalogs import available_catalogs as available_catalogs
+from swvo.io.substorms.supermag import SubstormsSuperMAG as SubstormsSuperMAG

--- a/swvo/io/substorms/catalogs.py
+++ b/swvo/io/substorms/catalogs.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
+# SPDX-FileContributor: Simon Mischel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Metadata for the substorm-onset catalogues distributed by SuperMAG."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class SuperMAGSubstormCatalog:
+    """Description of one SuperMAG substorm-onset catalogue."""
+
+    name: str
+    label: str
+    aliases: tuple[str, ...]
+    method: str
+    coverage: str
+    continuously_updated: bool
+    location_description: str
+    reference: str
+
+
+SUPERMAG_SUBSTORM_CATALOGS: tuple[SuperMAGSubstormCatalog, ...] = (
+    SuperMAGSubstormCatalog(
+        name="newell",
+        label="Newell and Gjerloev (2011)",
+        aliases=("newell_gjerloev",),
+        method="Automated onset identification from one-minute SML changes",
+        coverage="1969-current",
+        continuously_updated=True,
+        location_description="Location of the station contributing to SML at onset",
+        reference="https://doi.org/10.1029/2011JA016779",
+    ),
+    SuperMAGSubstormCatalog(
+        name="forsyth",
+        label="Forsyth et al. (2015), SOPHIE",
+        aliases=("sophie",),
+        method="SOPHIE expansion-phase onset identification from filtered SML",
+        coverage="1969-current",
+        continuously_updated=True,
+        location_description="Location of the station contributing to SML at onset",
+        reference="https://doi.org/10.1002/2015JA021343",
+    ),
+    SuperMAGSubstormCatalog(
+        name="ohtani",
+        label="Ohtani and Gjerloev (2020)",
+        aliases=("ohtani_gjerloev",),
+        method="High-confidence isolated-substorm identification from SML",
+        coverage="1969-current",
+        continuously_updated=True,
+        location_description="Location of the station contributing to SML at onset",
+        reference="https://doi.org/10.1029/2020JA027902",
+    ),
+    SuperMAGSubstormCatalog(
+        name="frey",
+        label="Frey et al. (2004 and 2006)",
+        aliases=("frey_mende",),
+        method="Auroral-onset identification from IMAGE-FUV observations",
+        coverage="2000-05-19 to 2002-12-31",
+        continuously_updated=False,
+        location_description="Auroral brightening location derived from IMAGE-FUV observations",
+        reference="https://doi.org/10.1029/2004JA010607",
+    ),
+    SuperMAGSubstormCatalog(
+        name="liou",
+        label="Liou (2010)",
+        aliases=(),
+        method="Auroral-breakup identification from Polar UVI observations",
+        coverage="Parts of 1996-2000 and 2007",
+        continuously_updated=False,
+        location_description="Auroral breakup location derived from Polar UVI observations",
+        reference="https://doi.org/10.1029/2010JA015578",
+    ),
+)
+
+
+def available_catalogs() -> pd.DataFrame:
+    """Return metadata for every SuperMAG substorm-onset catalogue.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A new table in registry order with canonical names, labels, aliases,
+        methods, coverage, update behavior, location interpretation, and
+        references.
+    """
+
+    return pd.DataFrame(
+        [
+            {
+                "name": catalog.name,
+                "label": catalog.label,
+                "aliases": catalog.aliases,
+                "method": catalog.method,
+                "coverage": catalog.coverage,
+                "continuously_updated": catalog.continuously_updated,
+                "location_description": catalog.location_description,
+                "reference": catalog.reference,
+            }
+            for catalog in SUPERMAG_SUBSTORM_CATALOGS
+        ]
+    )

--- a/swvo/io/substorms/supermag.py
+++ b/swvo/io/substorms/supermag.py
@@ -1,0 +1,495 @@
+# SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
+# SPDX-FileContributor: Simon Mischel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Download and read substorm-onset catalogues from SuperMAG."""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from time import sleep
+
+import pandas as pd
+import requests
+
+from swvo.io.base import BaseIO
+from swvo.io.substorms.catalogs import (
+    SUPERMAG_SUBSTORM_CATALOGS,
+    SuperMAGSubstormCatalog,
+)
+from swvo.io.substorms.catalogs import (
+    available_catalogs as get_available_catalogs,
+)
+from swvo.io.utils import enforce_utc_timezone
+
+logger = logging.getLogger(__name__)
+
+
+class _TransientSuperMAGEventResponseError(ValueError):
+    """Response error that can reasonably succeed when requested again."""
+
+
+class SubstormsSuperMAG(BaseIO):
+    """Reader for the substorm-onset catalogues distributed by SuperMAG.
+
+    The reader retrieves one scientifically distinct catalogue at a time.
+    ``"newell"`` is the default; ``"sophie"`` is accepted as an alias for
+    SuperMAG's canonical ``"forsyth"`` identifier.
+
+    Parameters
+    ----------
+    username : str
+        Registered SuperMAG username used for data access.
+    data_dir : Path | None
+        Root directory for SuperMAG caches. If omitted, the directory is read
+        from ``SUPERMAG_STREAM_DIR``.
+    prefer_env_var : bool, optional
+        If ``True``, ``SUPERMAG_STREAM_DIR`` takes precedence over
+        ``data_dir``. Defaults to ``False``.
+
+    Raises
+    ------
+    TypeError
+        If ``username`` is not a string.
+    ValueError
+        If ``username`` is empty or no data directory is configured.
+    """
+
+    ENV_VAR_NAME = "SUPERMAG_STREAM_DIR"
+    URL = "https://supermag.jhuapl.edu/lib/services/"
+    LABEL = "supermag_substorms"
+
+    _DEFAULT_CATALOG = "newell"
+    _OUTPUT_COLUMNS = ("mlt", "mlat", "glon", "glat", "catalog", "file_name")
+    _TABLE_HEADER = ("<year>", "<month>", "<day>", "<hour>", "<min>", "<mlt>", "<mlat>", "<glon>", "<glat>")
+    _MAX_DOWNLOAD_ATTEMPTS = 4
+    _RETRY_BACKOFF_SECONDS = 1.0
+
+    def __init__(self, username: str, data_dir: Path | None = None, prefer_env_var: bool = False) -> None:
+        if not isinstance(username, str):
+            raise TypeError("username must be a string")
+        if not username.strip():
+            raise ValueError("username must not be empty")
+        super().__init__(data_dir, prefer_env_var)
+        self.username = username
+
+    def available_catalogs(self) -> pd.DataFrame:
+        """Return metadata for the supported substorm-onset catalogues."""
+
+        return get_available_catalogs()
+
+    def download_and_process(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        reprocess_files: bool = False,
+        *,
+        catalog: str = _DEFAULT_CATALOG,
+    ) -> None:
+        """Download validated annual files for one SuperMAG onset catalogue.
+
+        SuperMAG's self-documented ASCII response is retained so that its data
+        revision, generation date, caveats, and acknowledgement text remain
+        available with the cached events.
+
+        Parameters
+        ----------
+        start_time : datetime
+            First requested instant. Naive values are interpreted as UTC.
+        end_time : datetime
+            Last requested instant. Naive values are interpreted as UTC.
+        reprocess_files : bool, optional
+            Replace existing annual files. This is useful for the continuously
+            revised index-derived catalogues. Defaults to ``False``.
+        catalog : str, optional
+            Canonical catalogue name or documented alias. Defaults to
+            ``"newell"``.
+
+        Raises
+        ------
+        TypeError
+            If ``catalog`` is not a string.
+        ValueError
+            If the interval or catalogue is invalid, or SuperMAG returns a
+            permanent error.
+        requests.RequestException
+            If a non-retryable request fails.
+        """
+
+        if start_time >= end_time:
+            raise ValueError("start_time must be before end_time")
+
+        start_time = enforce_utc_timezone(start_time)
+        end_time = enforce_utc_timezone(end_time)
+        selected_catalog = self._resolve_catalog(catalog)
+        self._resolved_urls = []
+        file_paths, years = self._get_cache_file_list(start_time, end_time, selected_catalog)
+
+        failed_years: list[int] = []
+        for file_path, year in zip(file_paths, years, strict=True):
+            if file_path.exists() and not reprocess_files:
+                try:
+                    self._read_single_file(file_path, selected_catalog, year)
+                except (OSError, UnicodeError, ValueError):
+                    logger.warning(
+                        "Replacing invalid SuperMAG %s event cache for %d",
+                        selected_catalog.name,
+                        year,
+                    )
+                else:
+                    continue
+            try:
+                self._download_and_process_single_file(file_path, year, selected_catalog)
+            except Exception as error:
+                if not self._is_retryable_download_error(error):
+                    raise
+                failed_years.append(year)
+                logger.error(
+                    "SuperMAG %s event download failed for %d after %d attempts (%s)",
+                    selected_catalog.name,
+                    year,
+                    self._MAX_DOWNLOAD_ATTEMPTS,
+                    self._retry_reason(error),
+                )
+
+        if failed_years:
+            years_text = ", ".join(str(year) for year in failed_years)
+            year_label = "year" if len(failed_years) == 1 else "years"
+            warnings.warn(
+                f"SuperMAG {selected_catalog.name} event download failed after "
+                f"{self._MAX_DOWNLOAD_ATTEMPTS} attempts for {len(failed_years)} "
+                f"{year_label}: {years_text}. Re-run the same range to retry failed years.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    def read(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        download: bool = False,
+        *,
+        catalog: str = _DEFAULT_CATALOG,
+    ) -> pd.DataFrame:
+        """Read one SuperMAG substorm-onset catalogue.
+
+        Parameters
+        ----------
+        start_time : datetime
+            First onset time to include. Naive values are interpreted as UTC.
+        end_time : datetime
+            Last onset time to include. Naive values are interpreted as UTC.
+        download : bool, optional
+            Download missing annual files and replace corrupt files. Defaults
+            to ``False``.
+        catalog : str, optional
+            Canonical catalogue name or documented alias. Defaults to
+            ``"newell"``.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Sparse onset records indexed by timezone-aware UTC ``onset``.
+            Columns are ``mlt`` (hours), ``mlat`` (degrees), ``glon``
+            (degrees), ``glat`` (degrees), canonical ``catalog``, and
+            ``file_name`` provenance.
+
+        Raises
+        ------
+        TypeError
+            If ``catalog`` is not a string.
+        ValueError
+            If the interval or catalogue is invalid, a cache is corrupt while
+            downloading is disabled, or a downloaded response is invalid.
+
+        Notes
+        -----
+        The location in index-derived catalogues is the location of the
+        station contributing to SML at onset, not necessarily the physical
+        auroral breakup location.
+        """
+
+        if start_time > end_time:
+            raise ValueError("start_time must be before or equal to end_time")
+
+        start_time = enforce_utc_timezone(start_time)
+        end_time = enforce_utc_timezone(end_time)
+        selected_catalog = self._resolve_catalog(catalog)
+        if download:
+            self._resolved_urls = []
+
+        file_paths, years = self._get_cache_file_list(start_time, end_time, selected_catalog)
+        frames: list[pd.DataFrame] = []
+
+        for file_path, year in zip(file_paths, years, strict=True):
+            if not file_path.exists():
+                if download:
+                    self._download_and_process_single_file(file_path, year, selected_catalog)
+                else:
+                    warnings.warn(
+                        f"File {file_path} not found. Re-run with download=True to retrieve it.",
+                        stacklevel=2,
+                    )
+                    continue
+
+            try:
+                frame = self._read_single_file(file_path, selected_catalog, year)
+            except (OSError, UnicodeError, ValueError) as error:
+                if not download:
+                    raise ValueError(
+                        f"Cannot read SuperMAG event cache {file_path}. "
+                        "Re-run with download=True to replace the corrupt file."
+                    ) from error
+                self._download_and_process_single_file(file_path, year, selected_catalog)
+                frame = self._read_single_file(file_path, selected_catalog, year)
+
+            frame["catalog"] = selected_catalog.name
+            frame["file_name"] = file_path
+            frames.append(frame)
+
+        if frames:
+            result = pd.concat(frames).sort_index(kind="stable")
+            result = result.loc[(result.index >= start_time) & (result.index <= end_time)]
+        else:
+            result = self._empty_events()
+
+        return result.loc[:, self._OUTPUT_COLUMNS]
+
+    def _download_and_process_single_file(
+        self,
+        file_path: Path,
+        year: int,
+        catalog: SuperMAGSubstormCatalog,
+    ) -> None:
+        """Download, validate, and atomically install one annual cache."""
+
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = file_path.with_suffix(f"{file_path.suffix}.tmp")
+        start = datetime(year, 1, 1, tzinfo=timezone.utc)
+        # SuperMAG includes events exactly at both request boundaries. Ending
+        # at the last second of the year avoids duplicating a New Year's event
+        # in two adjacent annual cache files.
+        end = datetime(year + 1, 1, 1, tzinfo=timezone.utc) - timedelta(seconds=1)
+        params = {
+            "service": "substorms",
+            "downloadtype": "substorm_list",
+            "user": self.username,
+            "fmt": "ascii",
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "list": catalog.name,
+        }
+
+        self._record_sanitized_url(params)
+        for attempt in range(1, self._MAX_DOWNLOAD_ATTEMPTS + 1):
+            logger.debug(
+                "Downloading SuperMAG %s events for %d (attempt %d/%d)",
+                catalog.name,
+                year,
+                attempt,
+                self._MAX_DOWNLOAD_ATTEMPTS,
+            )
+            try:
+                response = requests.get(self.URL, params=params, timeout=30)
+                response.raise_for_status()
+                parsed = self._process_response_text(response.text, catalog)
+                self._validate_cache_year(parsed, year)
+                tmp_path.write_text(response.text, encoding="utf-8")
+                tmp_path.replace(file_path)
+                return
+            except Exception as error:
+                tmp_path.unlink(missing_ok=True)
+                if not self._is_retryable_download_error(error) or attempt == self._MAX_DOWNLOAD_ATTEMPTS:
+                    raise
+
+                backoff = self._RETRY_BACKOFF_SECONDS * 2 ** (attempt - 1)
+                logger.warning(
+                    "Transient SuperMAG %s event failure for %d (%s); retrying in %.1f seconds (attempt %d/%d)",
+                    catalog.name,
+                    year,
+                    self._retry_reason(error),
+                    backoff,
+                    attempt + 1,
+                    self._MAX_DOWNLOAD_ATTEMPTS,
+                )
+                sleep(backoff)
+
+    def _record_sanitized_url(self, params: dict[str, str]) -> None:
+        """Record request provenance without exposing the SuperMAG username."""
+
+        public_params = {**params, "user": "<redacted>"}
+        resolved_url = requests.Request("GET", self.URL, params=public_params).prepare().url
+        if resolved_url is None:
+            raise ValueError("Could not resolve the SuperMAG event request URL")
+        self._record_url(resolved_url)
+
+    def _get_cache_file_list(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        catalog: SuperMAGSubstormCatalog,
+    ) -> tuple[list[Path], list[int]]:
+        """Return annual cache paths and their matching years."""
+
+        years = list(range(start_time.year, end_time.year + 1))
+        catalog_dir = self.data_dir / "substorms" / catalog.name
+        file_paths = [catalog_dir / f"SuperMAG_SUBSTORMS_{catalog.name.upper()}_{year}.txt" for year in years]
+        return file_paths, years
+
+    def _read_single_file(
+        self,
+        file_path: Path,
+        catalog: SuperMAGSubstormCatalog,
+        year: int,
+    ) -> pd.DataFrame:
+        """Parse one cached self-documented SuperMAG response."""
+
+        frame = self._process_response_text(file_path.read_text(encoding="utf-8"), catalog)
+        self._validate_cache_year(frame, year)
+        return frame
+
+    def _process_response_text(
+        self,
+        text: str,
+        catalog: SuperMAGSubstormCatalog,
+    ) -> pd.DataFrame:
+        """Parse and validate a self-documented SuperMAG event response."""
+
+        response_text = text.strip()
+        if not response_text:
+            raise _TransientSuperMAGEventResponseError("SuperMAG returned an empty response")
+        if response_text.startswith("ERROR"):
+            first_line = response_text.splitlines()[0]
+            raise ValueError(f"SuperMAG {first_line}")
+
+        lines = response_text.splitlines()
+        header_index = next(
+            (index for index, line in enumerate(lines) if tuple(line.strip().lower().split()) == self._TABLE_HEADER),
+            None,
+        )
+        if header_index is None:
+            raise ValueError(f"SuperMAG {catalog.name} event response does not contain the expected table header")
+
+        records: list[list[str]] = []
+        for line_number, line in enumerate(lines[header_index + 1 :], start=header_index + 2):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            fields = stripped.split()
+            if len(fields) != len(self._TABLE_HEADER):
+                raise ValueError(
+                    f"Malformed SuperMAG event record on response line {line_number}: "
+                    f"expected {len(self._TABLE_HEADER)} fields, found {len(fields)}"
+                )
+            records.append(fields)
+
+        if not records:
+            return self._empty_measurements()
+
+        columns = ("year", "month", "day", "hour", "minute", "mlt", "mlat", "glon", "glat")
+        frame = pd.DataFrame(records, columns=columns)
+        for column in columns:
+            numeric = pd.to_numeric(frame[column], errors="coerce")
+            if numeric.isna().any():
+                raise ValueError(f"SuperMAG event response contains a non-numeric {column} value")
+            frame[column] = numeric
+
+        # SuperMAG labels the Liou field as MLT but serves the original values
+        # in magnetic-longitude degrees. Liou (2010) reports MLT in hours, so
+        # normalize that one catalogue by the standard 15 degrees per hour.
+        if catalog.name == "liou":
+            frame["mlt"] = frame["mlt"] / 15
+
+        timestamps = pd.to_datetime(
+            {
+                "year": frame.pop("year"),
+                "month": frame.pop("month"),
+                "day": frame.pop("day"),
+                "hour": frame.pop("hour"),
+                "minute": frame.pop("minute"),
+            },
+            utc=True,
+            errors="coerce",
+        )
+        if timestamps.isna().any():
+            raise ValueError("SuperMAG event response contains an invalid onset time")
+
+        frame.index = pd.DatetimeIndex(timestamps, name="onset")
+        return frame.loc[:, ["mlt", "mlat", "glon", "glat"]]
+
+    @staticmethod
+    def _validate_cache_year(frame: pd.DataFrame, year: int) -> None:
+        """Ensure an annual response contains no records from another year."""
+
+        if any(pd.Timestamp(value).year != year for value in frame.index):
+            raise ValueError(f"SuperMAG event response for {year} contains an onset outside that year")
+
+    @classmethod
+    def _resolve_catalog(cls, catalog: str) -> SuperMAGSubstormCatalog:
+        """Validate a catalogue name and normalize documented aliases."""
+
+        if not isinstance(catalog, str):
+            raise TypeError("catalog must be a string")
+
+        normalized = catalog.strip().lower().replace("-", "_").replace(" ", "_")
+        if not normalized:
+            raise ValueError("catalog must not be empty")
+
+        for candidate in SUPERMAG_SUBSTORM_CATALOGS:
+            if normalized == candidate.name or normalized in candidate.aliases:
+                return candidate
+
+        available = ", ".join(candidate.name for candidate in SUPERMAG_SUBSTORM_CATALOGS)
+        raise ValueError(f"Unknown SuperMAG substorm catalog: {catalog!r}. Available catalogs: {available}")
+
+    @staticmethod
+    def _empty_measurements() -> pd.DataFrame:
+        """Return an empty parsed-event table with a UTC onset index."""
+
+        index = pd.DatetimeIndex([], tz=timezone.utc, name="onset")
+        return pd.DataFrame(index=index, columns=["mlt", "mlat", "glon", "glat"], dtype=float)
+
+    @classmethod
+    def _empty_events(cls) -> pd.DataFrame:
+        """Return an empty public event table with stable column types."""
+
+        frame = cls._empty_measurements()
+        frame["catalog"] = pd.Series(index=frame.index, dtype="object")
+        frame["file_name"] = pd.Series(index=frame.index, dtype="object")
+        return frame
+
+    @staticmethod
+    def _is_retryable_download_error(error: Exception) -> bool:
+        """Return whether ``error`` represents a transient download failure."""
+
+        if isinstance(
+            error,
+            (
+                _TransientSuperMAGEventResponseError,
+                requests.Timeout,
+                requests.ConnectionError,
+            ),
+        ):
+            return True
+        if isinstance(error, requests.HTTPError) and error.response is not None:
+            status_code = error.response.status_code
+            return status_code == 429 or status_code >= 500
+        return False
+
+    @staticmethod
+    def _retry_reason(error: Exception) -> str:
+        """Return a log-safe failure description without a prepared URL."""
+
+        if isinstance(error, _TransientSuperMAGEventResponseError):
+            return str(error)
+        if isinstance(error, requests.Timeout):
+            return "request timed out"
+        if isinstance(error, requests.ConnectionError):
+            return "connection failed"
+        if isinstance(error, requests.HTTPError) and error.response is not None:
+            return f"HTTP {error.response.status_code}"
+        return type(error).__name__

--- a/swvo/io/substorms/supermag.py
+++ b/swvo/io/substorms/supermag.py
@@ -421,15 +421,13 @@ class SubstormsSuperMAG(BaseIO):
         frame.index = pd.DatetimeIndex(timestamps, name="onset")
         return frame.loc[:, ["mlt", "mlat", "glon", "glat"]]
 
-    @staticmethod
-    def _validate_cache_year(frame: pd.DataFrame, year: int) -> None:
+    def _validate_cache_year(self, frame: pd.DataFrame, year: int) -> None:
         """Ensure an annual response contains no records from another year."""
 
         if any(pd.Timestamp(value).year != year for value in frame.index):
             raise ValueError(f"SuperMAG event response for {year} contains an onset outside that year")
 
-    @classmethod
-    def _resolve_catalog(cls, catalog: str) -> SuperMAGSubstormCatalog:
+    def _resolve_catalog(self, catalog: str) -> SuperMAGSubstormCatalog:
         """Validate a catalogue name and normalize documented aliases."""
 
         if not isinstance(catalog, str):
@@ -446,24 +444,21 @@ class SubstormsSuperMAG(BaseIO):
         available = ", ".join(candidate.name for candidate in SUPERMAG_SUBSTORM_CATALOGS)
         raise ValueError(f"Unknown SuperMAG substorm catalog: {catalog!r}. Available catalogs: {available}")
 
-    @staticmethod
-    def _empty_measurements() -> pd.DataFrame:
+    def _empty_measurements(self) -> pd.DataFrame:
         """Return an empty parsed-event table with a UTC onset index."""
 
         index = pd.DatetimeIndex([], tz=timezone.utc, name="onset")
         return pd.DataFrame(index=index, columns=["mlt", "mlat", "glon", "glat"], dtype=float)
 
-    @classmethod
-    def _empty_events(cls) -> pd.DataFrame:
+    def _empty_events(self) -> pd.DataFrame:
         """Return an empty public event table with stable column types."""
 
-        frame = cls._empty_measurements()
+        frame = self._empty_measurements()
         frame["catalog"] = pd.Series(index=frame.index, dtype="object")
         frame["file_name"] = pd.Series(index=frame.index, dtype="object")
         return frame
 
-    @staticmethod
-    def _is_retryable_download_error(error: Exception) -> bool:
+    def _is_retryable_download_error(self, error: Exception) -> bool:
         """Return whether ``error`` represents a transient download failure."""
 
         if isinstance(
@@ -480,8 +475,7 @@ class SubstormsSuperMAG(BaseIO):
             return status_code == 429 or status_code >= 500
         return False
 
-    @staticmethod
-    def _retry_reason(error: Exception) -> str:
+    def _retry_reason(self, error: Exception) -> str:
         """Return a log-safe failure description without a prepared URL."""
 
         if isinstance(error, _TransientSuperMAGEventResponseError):

--- a/tests/io/substorms/test_supermag_substorms.py
+++ b/tests/io/substorms/test_supermag_substorms.py
@@ -163,25 +163,30 @@ class TestCatalogSelectionAndFileNames:
             ("liou", "liou"),
         ],
     )
-    def test_catalog_names_and_aliases(self, requested: str, canonical: str):
-        assert SubstormsSuperMAG._resolve_catalog(requested).name == canonical
+    def test_catalog_names_and_aliases(
+        self,
+        reader: SubstormsSuperMAG,
+        requested: str,
+        canonical: str,
+    ):
+        assert reader._resolve_catalog(requested).name == canonical
 
     @pytest.mark.parametrize("catalog", [None, 1, ["newell"]])
-    def test_catalog_must_be_a_string(self, catalog):
+    def test_catalog_must_be_a_string(self, reader: SubstormsSuperMAG, catalog):
         with pytest.raises(TypeError, match="catalog must be a string"):
-            SubstormsSuperMAG._resolve_catalog(catalog)
+            reader._resolve_catalog(catalog)
 
     @pytest.mark.parametrize("catalog", ["", " ", "\n"])
-    def test_catalog_must_not_be_empty(self, catalog: str):
+    def test_catalog_must_not_be_empty(self, reader: SubstormsSuperMAG, catalog: str):
         with pytest.raises(ValueError, match="must not be empty"):
-            SubstormsSuperMAG._resolve_catalog(catalog)
+            reader._resolve_catalog(catalog)
 
-    def test_unknown_catalog_lists_canonical_choices(self):
+    def test_unknown_catalog_lists_canonical_choices(self, reader: SubstormsSuperMAG):
         with pytest.raises(
             ValueError,
             match=r"Unknown.*'other'.*newell, forsyth, ohtani, frey, liou",
         ):
-            SubstormsSuperMAG._resolve_catalog("other")
+            reader._resolve_catalog("other")
 
     def test_annual_cache_paths_are_catalog_specific(self, reader: SubstormsSuperMAG):
         paths, years = reader._get_cache_file_list(

--- a/tests/io/substorms/test_supermag_substorms.py
+++ b/tests/io/substorms/test_supermag_substorms.py
@@ -1,0 +1,898 @@
+# SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
+# SPDX-FileContributor: Simon Mischel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import os
+import warnings
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import Mock, call, patch
+
+import pandas as pd
+import pytest
+import requests
+
+from swvo.io.substorms import SubstormsSuperMAG, available_catalogs
+
+TEST_USERNAME = "test:user"
+UTC = timezone.utc
+
+
+def _ascii_response(
+    records: tuple[str, ...] = (
+        "2020 01 01 00 30 23.50 67.25 265.95 61.11",
+        "2020 01 01 01 45 00.25 68.00 212.83 64.70",
+        "2020 01 02 00 00 01.50 69.50 080.56 65.00",
+    ),
+    *,
+    catalog_label: str = "Newell and Gjerloev [2011]",
+) -> str:
+    rows = "\n".join(records)
+    return (
+        "All existing substorm onset identification techniques have limitations.\n"
+        f"File contains a list identified by {catalog_label}.\n"
+        "Substorm database generated on Tue, 31 Oct 2023 15:29:59 +0000.\n"
+        "Downloaded from https://supermag.jhuapl.edu/products/.\n"
+        "Data Revision:0006\n"
+        "============================================================\n"
+        "<year>\t<month>\t<day>\t<hour>\t<min>\t<mlt>\t<mlat>\t<glon>\t<glat>\n"
+        f"{rows}\n"
+    )
+
+
+def _response(text: str | None = None) -> Mock:
+    response = Mock()
+    response.text = _ascii_response() if text is None else text
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _http_error_response(status_code: int) -> Mock:
+    response = _response()
+    response.status_code = status_code
+    response.raise_for_status.side_effect = requests.HTTPError(
+        f"HTTP {status_code}",
+        response=response,
+    )
+    return response
+
+
+@pytest.fixture
+def reader(tmp_path: Path) -> SubstormsSuperMAG:
+    return SubstormsSuperMAG(TEST_USERNAME, data_dir=tmp_path)
+
+
+class TestInitializationAndDiscovery:
+    def test_initialization_with_explicit_data_dir(self, tmp_path: Path):
+        reader = SubstormsSuperMAG(TEST_USERNAME, data_dir=tmp_path)
+        assert reader.data_dir == tmp_path
+        assert reader.username == TEST_USERNAME
+        assert reader.url == SubstormsSuperMAG.URL
+
+    def test_initialization_with_environment_directory(self, tmp_path: Path):
+        with patch.dict(os.environ, {SubstormsSuperMAG.ENV_VAR_NAME: str(tmp_path)}):
+            reader = SubstormsSuperMAG(TEST_USERNAME)
+        assert reader.data_dir == tmp_path
+
+    def test_explicit_directory_takes_precedence_by_default(self, tmp_path: Path):
+        explicit = tmp_path / "explicit"
+        environment = tmp_path / "environment"
+        with patch.dict(os.environ, {SubstormsSuperMAG.ENV_VAR_NAME: str(environment)}):
+            reader = SubstormsSuperMAG(TEST_USERNAME, data_dir=explicit)
+        assert reader.data_dir == explicit
+
+    def test_environment_directory_can_be_preferred(self, tmp_path: Path):
+        explicit = tmp_path / "explicit"
+        environment = tmp_path / "environment"
+        with patch.dict(os.environ, {SubstormsSuperMAG.ENV_VAR_NAME: str(environment)}):
+            reader = SubstormsSuperMAG(
+                TEST_USERNAME,
+                data_dir=explicit,
+                prefer_env_var=True,
+            )
+        assert reader.data_dir == environment
+
+    @pytest.mark.parametrize("username", [None, 1, object()])
+    def test_username_must_be_a_string(self, tmp_path: Path, username):
+        with pytest.raises(TypeError, match="username must be a string"):
+            SubstormsSuperMAG(username, data_dir=tmp_path)
+
+    @pytest.mark.parametrize("username", ["", " ", "\t"])
+    def test_username_must_not_be_empty(self, tmp_path: Path, username: str):
+        with pytest.raises(ValueError, match="must not be empty"):
+            SubstormsSuperMAG(username, data_dir=tmp_path)
+
+    def test_missing_data_directory_configuration_is_reported(self):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(
+                ValueError,
+                match="SUPERMAG_STREAM_DIR",
+            ),
+        ):
+            SubstormsSuperMAG(TEST_USERNAME)
+
+    def test_available_catalogs_describes_all_official_lists(self, reader: SubstormsSuperMAG):
+        metadata = reader.available_catalogs()
+        assert metadata["name"].tolist() == [
+            "newell",
+            "forsyth",
+            "ohtani",
+            "frey",
+            "liou",
+        ]
+        assert list(metadata.columns) == [
+            "name",
+            "label",
+            "aliases",
+            "method",
+            "coverage",
+            "continuously_updated",
+            "location_description",
+            "reference",
+        ]
+        assert metadata.loc[metadata["name"] == "forsyth", "aliases"].item() == ("sophie",)
+        assert metadata.loc[metadata["name"] == "newell", "continuously_updated"].item()
+        assert not metadata.loc[metadata["name"] == "frey", "continuously_updated"].item()
+        assert metadata["reference"].str.startswith("https://doi.org/").all()
+
+    def test_module_discovery_returns_an_independent_table(self):
+        first = available_catalogs()
+        first.loc[0, "name"] = "changed"
+        second = available_catalogs()
+        assert second.loc[0, "name"] == "newell"
+
+
+class TestCatalogSelectionAndFileNames:
+    @pytest.mark.parametrize(
+        ("requested", "canonical"),
+        [
+            ("newell", "newell"),
+            ("NEWELL", "newell"),
+            ("newell-gjerloev", "newell"),
+            ("newell gjerloev", "newell"),
+            ("forsyth", "forsyth"),
+            ("sophie", "forsyth"),
+            (" SOPHIE ", "forsyth"),
+            ("ohtani_gjerloev", "ohtani"),
+            ("frey_mende", "frey"),
+            ("liou", "liou"),
+        ],
+    )
+    def test_catalog_names_and_aliases(self, requested: str, canonical: str):
+        assert SubstormsSuperMAG._resolve_catalog(requested).name == canonical
+
+    @pytest.mark.parametrize("catalog", [None, 1, ["newell"]])
+    def test_catalog_must_be_a_string(self, catalog):
+        with pytest.raises(TypeError, match="catalog must be a string"):
+            SubstormsSuperMAG._resolve_catalog(catalog)
+
+    @pytest.mark.parametrize("catalog", ["", " ", "\n"])
+    def test_catalog_must_not_be_empty(self, catalog: str):
+        with pytest.raises(ValueError, match="must not be empty"):
+            SubstormsSuperMAG._resolve_catalog(catalog)
+
+    def test_unknown_catalog_lists_canonical_choices(self):
+        with pytest.raises(
+            ValueError,
+            match=r"Unknown.*'other'.*newell, forsyth, ohtani, frey, liou",
+        ):
+            SubstormsSuperMAG._resolve_catalog("other")
+
+    def test_annual_cache_paths_are_catalog_specific(self, reader: SubstormsSuperMAG):
+        paths, years = reader._get_cache_file_list(
+            datetime(2019, 12, 31),
+            datetime(2021, 1, 1),
+            reader._resolve_catalog("sophie"),
+        )
+        assert years == [2019, 2020, 2021]
+        assert [path.name for path in paths] == [
+            "SuperMAG_SUBSTORMS_FORSYTH_2019.txt",
+            "SuperMAG_SUBSTORMS_FORSYTH_2020.txt",
+            "SuperMAG_SUBSTORMS_FORSYTH_2021.txt",
+        ]
+        assert all(path.parent == reader.data_dir / "substorms" / "forsyth" for path in paths)
+
+
+class TestResponseParsing:
+    def test_complete_response_schema_values_and_utc_index(self, reader: SubstormsSuperMAG):
+        result = reader._process_response_text(
+            _ascii_response(),
+            reader._resolve_catalog("newell"),
+        )
+        assert list(result.columns) == ["mlt", "mlat", "glon", "glat"]
+        assert result.index.name == "onset"
+        assert str(result.index.tz) == "UTC"
+        assert result.index.tolist() == [
+            pd.Timestamp("2020-01-01T00:30:00Z"),
+            pd.Timestamp("2020-01-01T01:45:00Z"),
+            pd.Timestamp("2020-01-02T00:00:00Z"),
+        ]
+        assert result.iloc[0].to_dict() == {
+            "mlt": 23.5,
+            "mlat": 67.25,
+            "glon": 265.95,
+            "glat": 61.11,
+        }
+        assert all(pd.api.types.is_numeric_dtype(result[column]) for column in result.columns)
+
+    def test_whitespace_separated_header_and_records_are_supported(self, reader: SubstormsSuperMAG):
+        text = _ascii_response().replace("\t", "    ")
+        result = reader._process_response_text(text, reader._resolve_catalog("newell"))
+        assert len(result) == 3
+
+    def test_valid_no_event_response_returns_typed_empty_table(self, reader: SubstormsSuperMAG):
+        result = reader._process_response_text(
+            _ascii_response(records=()),
+            reader._resolve_catalog("liou"),
+        )
+        assert result.empty
+        assert list(result.columns) == ["mlt", "mlat", "glon", "glat"]
+        assert result.index.name == "onset"
+        assert str(result.index.tz) == "UTC"
+        assert all(pd.api.types.is_float_dtype(result[column]) for column in result.columns)
+
+    @pytest.mark.parametrize(
+        ("text", "message"),
+        [
+            ("", "empty response"),
+            (" \n\t", "empty response"),
+            ("ERROR: Invalid username", "SuperMAG ERROR: Invalid username"),
+            ("an HTML proxy page", "expected table header"),
+            (
+                _ascii_response(records=("2020 01 01 00 30 23.5 67.2",)),
+                "expected 9 fields, found 7",
+            ),
+            (
+                _ascii_response(records=("2020 01 01 00 30 bad 67.2 265.9 61.1",)),
+                "non-numeric mlt",
+            ),
+            (
+                _ascii_response(records=("2020 13 01 00 30 23.5 67.2 265.9 61.1",)),
+                "invalid onset time",
+            ),
+        ],
+    )
+    def test_invalid_responses_are_rejected(
+        self,
+        reader: SubstormsSuperMAG,
+        text: str,
+        message: str,
+    ):
+        with pytest.raises(ValueError, match=message):
+            reader._process_response_text(text, reader._resolve_catalog("newell"))
+
+    def test_duplicate_onset_times_are_preserved(self, reader: SubstormsSuperMAG):
+        record = "2020 01 01 00 30 23.50 67.25 265.95 61.11"
+        result = reader._process_response_text(
+            _ascii_response(records=(record, record)),
+            reader._resolve_catalog("newell"),
+        )
+        assert len(result) == 2
+        assert result.index.duplicated().sum() == 1
+
+    def test_liou_mlt_degrees_are_normalized_to_hours(
+        self,
+        reader: SubstormsSuperMAG,
+    ):
+        result = reader._process_response_text(
+            _ascii_response(
+                records=("2000 01 06 19 36 337.90 63.80 39.90 68.00",),
+                catalog_label="Liou [2010]",
+            ),
+            reader._resolve_catalog("liou"),
+        )
+        assert result.iloc[0]["mlt"] == pytest.approx(337.9 / 15)
+
+
+class TestDownloadingAndAtomicCaches:
+    def test_exact_request_parameters_and_sanitized_provenance(
+        self,
+        reader: SubstormsSuperMAG,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level(logging.DEBUG)
+        with patch(
+            "swvo.io.substorms.supermag.requests.get",
+            return_value=_response(),
+        ) as get:
+            reader.download_and_process(
+                datetime(2020, 6, 1),
+                datetime(2020, 6, 2),
+                catalog="sophie",
+            )
+
+        get.assert_called_once_with(
+            SubstormsSuperMAG.URL,
+            params={
+                "service": "substorms",
+                "downloadtype": "substorm_list",
+                "user": TEST_USERNAME,
+                "fmt": "ascii",
+                "start": "2020-01-01T00:00:00+00:00",
+                "end": "2020-12-31T23:59:59+00:00",
+                "list": "forsyth",
+            },
+            timeout=30,
+        )
+        assert isinstance(reader.url, str)
+        assert "user=%3Credacted%3E" in reader.url
+        assert "list=forsyth" in reader.url
+        assert TEST_USERNAME not in reader.url
+        assert TEST_USERNAME not in caplog.text
+
+    @pytest.mark.parametrize("catalog", ["newell", "forsyth", "ohtani", "frey", "liou"])
+    def test_every_catalog_can_be_downloaded(
+        self,
+        reader: SubstormsSuperMAG,
+        catalog: str,
+    ):
+        with patch(
+            "swvo.io.substorms.supermag.requests.get",
+            return_value=_response(),
+        ) as get:
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+                catalog=catalog,
+            )
+        assert get.call_args.kwargs["params"]["list"] == catalog
+        path = reader.data_dir / "substorms" / catalog / f"SuperMAG_SUBSTORMS_{catalog.upper()}_2020.txt"
+        assert path.read_text(encoding="utf-8") == _ascii_response()
+
+    def test_valid_no_event_year_is_cached_without_retry(self, reader: SubstormsSuperMAG):
+        text = _ascii_response(records=())
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                return_value=_response(text),
+            ) as get,
+            patch("swvo.io.substorms.supermag.sleep") as retry_sleep,
+        ):
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+                catalog="liou",
+            )
+        get.assert_called_once()
+        retry_sleep.assert_not_called()
+        path = reader.data_dir / "substorms" / "liou" / "SuperMAG_SUBSTORMS_LIOU_2020.txt"
+        assert path.read_text(encoding="utf-8") == text
+
+    def test_out_of_year_record_is_rejected_before_cache_install(
+        self,
+        reader: SubstormsSuperMAG,
+    ):
+        text = _ascii_response(
+            records=("2021 01 01 00 00 00.25 68.00 212.83 64.70",),
+        )
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                return_value=_response(text),
+            ),
+            pytest.raises(ValueError, match="outside that year"),
+        ):
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+
+        path = reader.data_dir / "substorms" / "newell" / "SuperMAG_SUBSTORMS_NEWELL_2020.txt"
+        assert not path.exists()
+
+    def test_existing_cache_is_not_replaced_without_reprocess(self, reader: SubstormsSuperMAG):
+        catalog = reader._resolve_catalog("newell")
+        path = reader._get_cache_file_list(
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 2),
+            catalog,
+        )[0][0]
+        path.parent.mkdir(parents=True)
+        path.write_text(_ascii_response(records=()), encoding="utf-8")
+
+        with patch("swvo.io.substorms.supermag.requests.get") as get:
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+        get.assert_not_called()
+
+    def test_reprocess_replaces_existing_cache(self, reader: SubstormsSuperMAG):
+        catalog = reader._resolve_catalog("newell")
+        path = reader._get_cache_file_list(
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 2),
+            catalog,
+        )[0][0]
+        path.parent.mkdir(parents=True)
+        path.write_text(_ascii_response(records=()), encoding="utf-8")
+
+        with patch(
+            "swvo.io.substorms.supermag.requests.get",
+            return_value=_response(),
+        ) as get:
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+                reprocess_files=True,
+            )
+        get.assert_called_once()
+        assert path.read_text(encoding="utf-8") == _ascii_response()
+
+    def test_batch_download_replaces_corrupt_cache_without_reprocess(
+        self,
+        reader: SubstormsSuperMAG,
+    ):
+        catalog = reader._resolve_catalog("newell")
+        path = reader._get_cache_file_list(
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 2),
+            catalog,
+        )[0][0]
+        path.parent.mkdir(parents=True)
+        path.write_text("corrupt", encoding="utf-8")
+
+        with patch(
+            "swvo.io.substorms.supermag.requests.get",
+            return_value=_response(),
+        ) as get:
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+
+        get.assert_called_once()
+        assert path.read_text(encoding="utf-8") == _ascii_response()
+
+    def test_zero_byte_response_is_retried_then_succeeds(self, reader: SubstormsSuperMAG):
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                side_effect=[_response(""), _response()],
+            ) as get,
+            patch("swvo.io.substorms.supermag.sleep") as retry_sleep,
+        ):
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+        assert get.call_count == 2
+        retry_sleep.assert_called_once_with(1.0)
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            requests.Timeout("timed out"),
+            requests.ConnectionError("connection failed"),
+        ],
+    )
+    def test_request_failures_are_retried(
+        self,
+        reader: SubstormsSuperMAG,
+        error: requests.RequestException,
+    ):
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                side_effect=[error, _response()],
+            ) as get,
+            patch("swvo.io.substorms.supermag.sleep") as retry_sleep,
+        ):
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+        assert get.call_count == 2
+        retry_sleep.assert_called_once_with(1.0)
+
+    @pytest.mark.parametrize("status_code", [429, 500, 503])
+    def test_retryable_http_statuses(
+        self,
+        reader: SubstormsSuperMAG,
+        status_code: int,
+    ):
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                side_effect=[_http_error_response(status_code), _response()],
+            ) as get,
+            patch("swvo.io.substorms.supermag.sleep") as retry_sleep,
+        ):
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+        assert get.call_count == 2
+        retry_sleep.assert_called_once_with(1.0)
+
+    def test_exhausted_transient_year_warns_and_batch_continues(
+        self,
+        reader: SubstormsSuperMAG,
+    ):
+        responses = [_response("") for _ in range(reader._MAX_DOWNLOAD_ATTEMPTS)]
+        responses.append(
+            _response(
+                _ascii_response(
+                    records=("2021 01 01 00 30 23.50 67.25 265.95 61.11",),
+                )
+            )
+        )
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                side_effect=responses,
+            ) as get,
+            patch("swvo.io.substorms.supermag.sleep") as retry_sleep,
+            pytest.warns(
+                RuntimeWarning,
+                match=r"newell.*4 attempts.*1 year.*2020.*Re-run",
+            ),
+        ):
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2021, 1, 2),
+            )
+
+        assert get.call_count == reader._MAX_DOWNLOAD_ATTEMPTS + 1
+        assert retry_sleep.call_args_list == [call(1.0), call(2.0), call(4.0)]
+        assert not (reader.data_dir / "substorms" / "newell" / "SuperMAG_SUBSTORMS_NEWELL_2020.txt").exists()
+        assert (reader.data_dir / "substorms" / "newell" / "SuperMAG_SUBSTORMS_NEWELL_2021.txt").exists()
+
+    def test_permanent_supermag_error_is_not_retried(self, reader: SubstormsSuperMAG):
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                return_value=_response("ERROR: Invalid username"),
+            ) as get,
+            patch("swvo.io.substorms.supermag.sleep") as retry_sleep,
+            pytest.raises(ValueError, match="Invalid username"),
+        ):
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+        get.assert_called_once()
+        retry_sleep.assert_not_called()
+
+    def test_non_retryable_http_error_is_not_retried(self, reader: SubstormsSuperMAG):
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                return_value=_http_error_response(404),
+            ) as get,
+            patch("swvo.io.substorms.supermag.sleep") as retry_sleep,
+            pytest.raises(requests.HTTPError, match="404"),
+        ):
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+        get.assert_called_once()
+        retry_sleep.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "side_effect",
+        [
+            requests.Timeout("timed out"),
+            requests.ConnectionError("connection failed"),
+        ],
+    )
+    def test_failed_reprocess_preserves_cache_and_removes_temporary_file(
+        self,
+        reader: SubstormsSuperMAG,
+        side_effect: requests.RequestException,
+    ):
+        catalog = reader._resolve_catalog("newell")
+        path = reader._get_cache_file_list(
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 2),
+            catalog,
+        )[0][0]
+        path.parent.mkdir(parents=True)
+        original = _ascii_response(records=())
+        path.write_text(original, encoding="utf-8")
+
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                side_effect=side_effect,
+            ),
+            patch("swvo.io.substorms.supermag.sleep"),
+            pytest.raises(type(side_effect), match=str(side_effect)),
+        ):
+            reader._download_and_process_single_file(path, 2020, catalog)
+
+        assert path.read_text(encoding="utf-8") == original
+        assert not path.with_suffix(".txt.tmp").exists()
+
+    def test_parse_failure_preserves_existing_cache(self, reader: SubstormsSuperMAG):
+        catalog = reader._resolve_catalog("newell")
+        path = reader._get_cache_file_list(
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 2),
+            catalog,
+        )[0][0]
+        path.parent.mkdir(parents=True)
+        original = _ascii_response(records=())
+        path.write_text(original, encoding="utf-8")
+
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                return_value=_response("not a catalogue"),
+            ),
+            pytest.raises(ValueError, match="expected table header"),
+        ):
+            reader._download_and_process_single_file(path, 2020, catalog)
+
+        assert path.read_text(encoding="utf-8") == original
+        assert not path.with_suffix(".txt.tmp").exists()
+
+    def test_write_failure_preserves_existing_cache(self, reader: SubstormsSuperMAG):
+        catalog = reader._resolve_catalog("newell")
+        path = reader._get_cache_file_list(
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 2),
+            catalog,
+        )[0][0]
+        path.parent.mkdir(parents=True)
+        original = _ascii_response(records=())
+        path.write_text(original, encoding="utf-8")
+
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                return_value=_response(),
+            ),
+            patch("pathlib.Path.write_text", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            reader._download_and_process_single_file(path, 2020, catalog)
+
+        assert path.read_text(encoding="utf-8") == original
+        assert not path.with_suffix(".txt.tmp").exists()
+
+    def test_download_rejects_equal_and_reversed_ranges(self, reader: SubstormsSuperMAG):
+        with pytest.raises(ValueError, match="before"):
+            reader.download_and_process(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1),
+            )
+        with pytest.raises(ValueError, match="before"):
+            reader.download_and_process(
+                datetime(2020, 1, 2),
+                datetime(2020, 1, 1),
+            )
+
+
+class TestReading:
+    @staticmethod
+    def _write_cache(
+        reader: SubstormsSuperMAG,
+        year: int,
+        text: str,
+        catalog: str = "newell",
+    ) -> Path:
+        selected = reader._resolve_catalog(catalog)
+        path = reader._get_cache_file_list(
+            datetime(year, 1, 1),
+            datetime(year, 1, 2),
+            selected,
+        )[0][0]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_default_read_schema_values_and_provenance(self, reader: SubstormsSuperMAG):
+        path = self._write_cache(reader, 2020, _ascii_response())
+        result = reader.read(
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 1, 2),
+        )
+        assert list(result.columns) == [
+            "mlt",
+            "mlat",
+            "glon",
+            "glat",
+            "catalog",
+            "file_name",
+        ]
+        assert len(result) == 2
+        assert result["catalog"].eq("newell").all()
+        assert result["file_name"].eq(path).all()
+
+    def test_alias_read_returns_canonical_catalog_name(self, reader: SubstormsSuperMAG):
+        path = self._write_cache(reader, 2020, _ascii_response(), catalog="forsyth")
+        result = reader.read(
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 1, 2),
+            catalog="sophie",
+        )
+        assert result["catalog"].eq("forsyth").all()
+        assert result["file_name"].eq(path).all()
+
+    def test_timezone_conversion_and_inclusive_boundaries(self, reader: SubstormsSuperMAG):
+        self._write_cache(reader, 2020, _ascii_response())
+        plus_one = timezone(timedelta(hours=1))
+        result = reader.read(
+            datetime(2020, 1, 1, 1, 30, tzinfo=plus_one),
+            datetime(2020, 1, 1, 2, 45, tzinfo=plus_one),
+        )
+        assert result.index.tolist() == [
+            pd.Timestamp("2020-01-01T00:30:00Z"),
+            pd.Timestamp("2020-01-01T01:45:00Z"),
+        ]
+
+    def test_equal_read_boundaries_select_exact_onset(self, reader: SubstormsSuperMAG):
+        self._write_cache(reader, 2020, _ascii_response())
+        onset = datetime(2020, 1, 1, 0, 30, tzinfo=UTC)
+        result = reader.read(onset, onset)
+        assert result.index.tolist() == [pd.Timestamp(onset)]
+
+    def test_reverse_read_range_is_rejected(self, reader: SubstormsSuperMAG):
+        with pytest.raises(ValueError, match="before or equal"):
+            reader.read(
+                datetime(2020, 1, 2),
+                datetime(2020, 1, 1),
+            )
+
+    def test_multiple_years_are_combined_and_sorted(self, reader: SubstormsSuperMAG):
+        self._write_cache(
+            reader,
+            2019,
+            _ascii_response(
+                records=("2019 12 31 23 59 23.50 67.25 265.95 61.11",),
+            ),
+        )
+        self._write_cache(
+            reader,
+            2020,
+            _ascii_response(
+                records=("2020 01 01 00 00 00.25 68.00 212.83 64.70",),
+            ),
+        )
+        result = reader.read(
+            datetime(2019, 12, 31, 23, 59),
+            datetime(2020, 1, 1, 0, 0),
+        )
+        assert result.index.tolist() == [
+            pd.Timestamp("2019-12-31T23:59:00Z"),
+            pd.Timestamp("2020-01-01T00:00:00Z"),
+        ]
+
+    def test_missing_cache_warns_and_returns_sparse_empty_schema(self, reader: SubstormsSuperMAG):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+        assert result.empty
+        assert list(result.columns) == list(SubstormsSuperMAG._OUTPUT_COLUMNS)
+        assert str(result.index.tz) == "UTC"
+        assert "download=True" in str(caught[-1].message)
+
+    def test_valid_empty_cache_does_not_warn(self, reader: SubstormsSuperMAG):
+        self._write_cache(reader, 2020, _ascii_response(records=()), catalog="liou")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+                catalog="liou",
+            )
+        assert result.empty
+        assert not caught
+
+    def test_missing_cache_is_downloaded_on_demand(self, reader: SubstormsSuperMAG):
+        with patch(
+            "swvo.io.substorms.supermag.requests.get",
+            return_value=_response(),
+        ) as get:
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 2),
+                download=True,
+            )
+        get.assert_called_once()
+        assert len(result) == 2
+
+    def test_complete_cache_does_not_download_again(self, reader: SubstormsSuperMAG):
+        self._write_cache(reader, 2020, _ascii_response())
+        with patch("swvo.io.substorms.supermag.requests.get") as get:
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 2),
+                download=True,
+            )
+        get.assert_not_called()
+        assert len(result) == 2
+
+    def test_corrupt_cache_reports_remediation_without_download(self, reader: SubstormsSuperMAG):
+        self._write_cache(reader, 2020, "corrupt")
+        with pytest.raises(
+            ValueError,
+            match=r"Cannot read.*download=True.*corrupt",
+        ):
+            reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+            )
+
+    def test_corrupt_cache_is_replaced_when_download_is_enabled(self, reader: SubstormsSuperMAG):
+        path = self._write_cache(reader, 2020, "corrupt")
+        with patch(
+            "swvo.io.substorms.supermag.requests.get",
+            return_value=_response(),
+        ) as get:
+            result = reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 1, 2),
+                download=True,
+            )
+        get.assert_called_once()
+        assert len(result) == 2
+        assert path.read_text(encoding="utf-8") == _ascii_response()
+
+    def test_strict_read_surfaces_exhausted_transient_failure(self, reader: SubstormsSuperMAG):
+        with (
+            patch(
+                "swvo.io.substorms.supermag.requests.get",
+                return_value=_response(""),
+            ) as get,
+            patch("swvo.io.substorms.supermag.sleep") as retry_sleep,
+            pytest.raises(ValueError, match="empty response"),
+        ):
+            reader.read(
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+                download=True,
+            )
+        assert get.call_count == reader._MAX_DOWNLOAD_ATTEMPTS
+        assert retry_sleep.call_args_list == [call(1.0), call(2.0), call(4.0)]
+
+
+@pytest.mark.skipif(
+    os.environ.get("SWVO_RUN_LIVE_TESTS") != "1",
+    reason="set SWVO_RUN_LIVE_TESTS=1 to run authenticated SuperMAG smoke tests",
+)
+@pytest.mark.parametrize(
+    ("catalog", "year"),
+    [
+        ("newell", 2001),
+        ("forsyth", 2001),
+        ("ohtani", 2001),
+        ("frey", 2001),
+        ("liou", 2000),
+    ],
+)
+def test_live_catalogue_download(
+    tmp_path: Path,
+    catalog: str,
+    year: int,
+):
+    username = os.environ.get("SUPERMAG_USERNAME")
+    if not username:
+        pytest.skip("SUPERMAG_USERNAME is not configured")
+
+    reader = SubstormsSuperMAG(username, data_dir=tmp_path)
+    events = reader.read(
+        datetime(year, 1, 1, tzinfo=UTC),
+        datetime(year, 12, 31, 23, 59, 59, tzinfo=UTC),
+        download=True,
+        catalog=catalog,
+    )
+
+    assert not events.empty
+    assert list(events.columns) == list(SubstormsSuperMAG._OUTPUT_COLUMNS)
+    assert str(events.index.tz) == "UTC"
+    assert events["catalog"].eq(catalog).all()
+    assert events[["mlt", "mlat", "glon", "glat"]].notna().all().all()
+    assert events["mlt"].between(0, 24).all()
+    assert events["mlat"].between(-90, 90).all()
+    assert events["glat"].between(-90, 90).all()


### PR DESCRIPTION
## Summary

This adds a new `SubstormsSuperMAG` reader for downloading and reading the five substorm-onset catalogues distributed through the SuperMAG Products service:

- Newell and Gjerloev (`newell`, default)
- Forsyth/SOPHIE (`forsyth`, alias `sophie`)
- Ohtani and Gjerloev (`ohtani`)
- Frey and Mende (`frey`)
- Liou (`liou`)

Each read returns sparse onset records with a timezone-aware UTC index and the columns `mlt`, `mlat`, `glon`, `glat`, `catalog`, and `file_name`.

## Usage

```python
import os
from datetime import datetime, timezone
from pathlib import Path

from swvo.io.substorms import SubstormsSuperMAG

reader = SubstormsSuperMAG(
    username=os.environ["SUPERMAG_USERNAME"],
    data_dir=Path("./supermag_data"),
)

events = reader.read(
    datetime(2001, 1, 1, tzinfo=timezone.utc),
    datetime(2001, 1, 2, tzinfo=timezone.utc),
    download=True,
    catalog="sophie",
)
```

`available_catalogs()` provides the supported names, aliases, references, methods, coverage, and update behavior without accessing the network.

One catalogue is deliberately returned per call. The catalogues use different scientific definitions and should not be combined or de-duplicated implicitly.

## Downloading, caching, and provenance

Responses are stored as self-documented annual ASCII files under:

```text
<data_dir>/substorms/<catalog>/SuperMAG_SUBSTORMS_<CATALOG>_<YEAR>.txt
```

The original validated SuperMAG response is retained so that its revision, generation time, caveats, acknowledgement text, and references remain available. The `file_name` column connects every returned event to its cached source.

Both requested interval boundaries are inclusive. Well-formed responses containing no events are treated as valid rather than as download failures.

Zero-byte responses, connection failures, timeouts, HTTP 429 responses, and HTTP 5xx responses are retried up to four times using bounded exponential backoff. Historical batch downloads continue with later years after an exhausted transient failure and report the affected years. On-demand reads remain strict when a required download cannot be completed.

Downloads are validated before atomically replacing cache files. Failed requests, parsing errors, and write failures preserve an existing cache and clean up temporary files.

The registered username is sent as an encoded request parameter. It is not written into cache files, exposed through URL provenance, or included in logs.

## Scientific handling

For the Newell, Forsyth, and Ohtani catalogues, the reported location is the station contributing to SML at onset. It should therefore be interpreted as a station-based proxy rather than automatically as the physical auroral-breakup location.

SuperMAG labels the Liou longitude-derived field as MLT while serving values in degrees. The reader converts these values to magnetic local time in hours using 15 degrees per hour. The original cached response remains unchanged.

The Forsyth product provided by SuperMAG is an onset list. It is distinct from the complete minute-by-minute SOPHIE growth, expansion, and recovery phase classification.

## Documentation

A dedicated user-guide page documents:

- Authentication and privacy
- Catalogue selection and aliases
- Catalogue methods, references, and coverage
- Output fields and units
- Location interpretation
- Liou coordinate normalization
- Annual cache layout and catalogue revisions
- Retry, corruption, and failure behavior
- SuperMAG rules of the road and acknowledgement requirements
- The distinction between SOPHIE onset records and full phase classification

The README and user-guide index link to the new documentation.

## Verification

- 81 deterministic mocked tests passed
- 5 authenticated live catalogue tests passed
- Ruff lint and formatting passed
- Ty type checking passed
- Strict Sphinx documentation build passed without warnings
- REUSE compliance passed for all 293 tracked files
- No credentials or downloaded SuperMAG datasets are included

The complete `tests/io` suite reports 768 passed, 19 skipped, 2 expected failures, and one failure in the existing live WDC test. WDC currently returns four monthly files while that test asserts a maximum of three. The same failure is present on current upstream `main`; this change does not modify WDC code or tests.
