### PR TITLE
ci: add apptainer def and build ci (closes #91)

### DIFF
--- a/.github/workflows/apptainer.yml
+++ b/.github/workflows/apptainer.yml
@@ -1,0 +1,48 @@
+name: Build and Push Apptainer Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "*.def"
+      - "swvo/**"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "download_daily_files.py"
+  workflow_dispatch:
+
+env:
+  APPTAINER_VERSION: "1.5.3"
+  IMAGE_NAME: swvo
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+
+      - name: Get SWVO package version
+        id: swvo_version
+        run: |
+          VERSION=$(grep -oP '(?<=^current_version = ")[^"]+' pyproject.toml)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install Apptainer
+        run: |
+          wget https://github.com/apptainer/apptainer/releases/download/v${{ env.APPTAINER_VERSION }}/apptainer_${{ env.APPTAINER_VERSION }}_amd64.deb
+          sudo apt-get update
+          sudo apt-get install -y ./apptainer_${{ env.APPTAINER_VERSION }}_amd64.deb
+
+      - name: Build image
+        run: sudo apptainer build ${{ env.IMAGE_NAME }}.sif swvo.def
+
+      - name: Log in to GHCR
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login -u ${{ github.actor }} --password-stdin oras://ghcr.io
+
+      - name: Push image
+        run: |
+          apptainer push ${{ env.IMAGE_NAME }}.sif oras://ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+          apptainer push ${{ env.IMAGE_NAME }}.sif oras://ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          apptainer push ${{ env.IMAGE_NAME }}.sif oras://ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.swvo_version.outputs.version }}

--- a/.github/workflows/apptainer.yml
+++ b/.github/workflows/apptainer.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
+# SPDX-FileContributor: Sahil Jhawar
+#
+# SPDX-License-Identifier: Apache-2.0
 name: Build and Push Apptainer Image
 
 on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ push = true
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ['current_version = "{version}"']
 "swvo/__init__.py" = ['__version__ = "{version}"']
+"apptainer.def" = ['    Version {version}']
 
 [tool.ty.src]
 include = ["swvo"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ push = true
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ['current_version = "{version}"']
 "swvo/__init__.py" = ['__version__ = "{version}"']
-"apptainer.def" = ['    Version {version}']
+"swvo.def" = ['    Version {version}']
 
 [tool.ty.src]
 include = ["swvo"]

--- a/swvo.def
+++ b/swvo.def
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2026 GFZ Helmholtz Centre for Geosciences
+# SPDX-FileContributor: Sahil Jhawar
+#
+# SPDX-License-Identifier: Apache-2.0
+
 Bootstrap: docker
 From: astral/uv:python3.12-bookworm-slim
 

--- a/swvo.def
+++ b/swvo.def
@@ -1,0 +1,31 @@
+Bootstrap: docker
+From: astral/uv:python3.12-bookworm-slim
+
+%labels
+    Author Sahil Jhawar
+    Description SWVO
+    Version 1.2.5
+
+%files
+    swvo /opt/swvo/
+    pyproject.toml /opt/swvo/
+    requirements.txt /opt/swvo/
+    download_daily_files.py /opt/swvo/
+
+%environment
+    export UV_PROJECT_ENVIRONMENT=/opt/swvo/.venv
+    export PATH="/opt/swvo:/opt/swvo/.venv/bin:/root/.local/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+%post
+    apt-get update
+    apt-get install -y --no-install-recommends curl ca-certificates build-essential
+    rm -rf /var/lib/apt/lists/*
+
+    export PATH="/root/.local/bin:$PATH"
+    export UV_PROJECT_ENVIRONMENT=/opt/swvo/.venv
+
+    cd /opt/swvo/
+    uv sync
+
+%runscript
+    exec "$@"


### PR DESCRIPTION
This pull request introduces Apptainer container support for the project, enabling automated building and publishing of container images via GitHub Actions. 

* Added a new GitHub Actions workflow (`.github/workflows/apptainer.yml`) to automatically build and push Apptainer images to GitHub Container Registry on every push to `main` or manual dispatch. The workflow installs Apptainer, builds the image from `swvo.def`, and pushes it with multiple tags (latest, commit SHA, and project version).
* Introduced an Apptainer definition file (`swvo.def`) specifying the container build process, including base image, labels, file inclusion, environment variables, dependency installation, and runscript.

* Updated `pyproject.toml` to track the version in `apptainer.def` for consistent version management across the codebase and container image.